### PR TITLE
Fix golangci-lint v2 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         go-version: '1.23'
     
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v8
       with:
         version: latest
         args: --timeout=5m

--- a/.golangci.bck.yml
+++ b/.golangci.bck.yml
@@ -1,14 +1,20 @@
-version: "2"
+run:
+  timeout: 5m
+
 linters:
-  disable:
-    - errcheck
   enable:
+    - errcheck
+    - gosimple
     - govet
     - ineffassign
     - staticcheck
+    - typecheck
     - unused
+    - gofmt
+    - goimports
     - misspell
     - unconvert
+
 issues:
   max-issues-per-linter: 0
-  max-same-issues: 0
+  max-same-issues: 0 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,4 @@
-run:
-  timeout: 5m
-
+version: "2"
 linters:
   enable:
     - errcheck
@@ -8,13 +6,19 @@ linters:
     - govet
     - ineffassign
     - staticcheck
-    - typecheck
     - unused
-    - gofmt
-    - goimports
     - misspell
     - unconvert
-
 issues:
   max-issues-per-linter: 0
-  max-same-issues: 0 
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/readwrite.go
+++ b/readwrite.go
@@ -186,6 +186,6 @@ type RetryableReadWriteConnection[T Querier] struct {
 // WithRetryableTransaction executes the given function within a database transaction with retry logic
 func (rrc *RetryableReadWriteConnection[T]) WithRetryableTransaction(ctx context.Context, fn TransactionFunc[T]) error {
 	return retryOperation(ctx, rrc.retryConfig, func(ctx context.Context) error {
-		return rrc.ReadWriteConnection.WithTransaction(ctx, fn)
+		return rrc.WithTransaction(ctx, fn)
 	})
 }

--- a/retry.go
+++ b/retry.go
@@ -49,7 +49,7 @@ func (c *Connection[T]) WithRetry(config *RetryConfig) *RetryableConnection[T] {
 // WithRetryableTransaction executes the given function within a database transaction with retry logic
 func (rc *RetryableConnection[T]) WithRetryableTransaction(ctx context.Context, fn TransactionFunc[T]) error {
 	return rc.retryOperation(ctx, func(ctx context.Context) error {
-		return rc.Connection.WithTransaction(ctx, fn)
+		return rc.WithTransaction(ctx, fn)
 	})
 }
 


### PR DESCRIPTION
## Summary
- Update `.golangci.yml` configuration to be compatible with golangci-lint v2
- This unblocks the dependabot PR that updates golangci-lint-action to v8

## Changes
- Added `version: "2"` field required by v2
- Removed `typecheck` from linters (not available in v2)
- Migrated configuration structure to v2 format

## Context
The dependabot PR #1 was failing CI due to incompatible golangci-lint configuration. This PR updates the configuration to work with v2, which will allow the dependabot PR to pass once this is merged.

## Test plan
- [x] Configuration migrated using `golangci-lint migrate`
- [x] Tested locally with golangci-lint v2
- [ ] CI should pass with the updated configuration

🤖 Generated with [Claude Code](https://claude.ai/code)