### PR TITLE
feat: Add GitHub Wiki setup documentation and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,17 @@ db.AddHook(pgxkit.BeforeOperation, func(ctx context.Context, sql string, args []
 })
 ```
 
+## Documentation
+
+📖 **[Visit our Wiki](https://github.com/nhalm/pgxkit/wiki)** for comprehensive documentation including:
+
+- **[Getting Started Guide](https://github.com/nhalm/pgxkit/wiki/Getting-Started)** - Setup and basic usage
+- **[Performance Guide](https://github.com/nhalm/pgxkit/wiki/Performance-Guide)** - Optimization strategies
+- **[Testing Guide](https://github.com/nhalm/pgxkit/wiki/Testing-Guide)** - Testing best practices
+- **[Production Guide](https://github.com/nhalm/pgxkit/wiki/Production-Guide)** - Deployment considerations
+- **[API Reference](https://github.com/nhalm/pgxkit/wiki/API-Reference)** - Complete API documentation
+- **[Examples](https://github.com/nhalm/pgxkit/wiki/Examples)** - Practical code examples
+
 ## Contributing
 
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.

--- a/WIKI_SETUP.md
+++ b/WIKI_SETUP.md
@@ -1,0 +1,94 @@
+# GitHub Wiki Setup Guide
+
+## Overview
+
+This guide provides instructions for enabling and setting up the GitHub Wiki for the pgxkit repository as part of Phase 1 of the documentation migration project.
+
+## Prerequisites
+
+- Repository admin access
+- GitHub account with necessary permissions
+
+## Step 1: Enable GitHub Wiki
+
+1. Navigate to the repository settings
+2. Go to the "Features" section
+3. Check the "Wikis" checkbox to enable the wiki feature
+4. Click "Save changes"
+
+## Step 2: Initial Wiki Structure
+
+Once the wiki is enabled, create the following initial pages:
+
+### Home Page (Home.md)
+The main landing page for the wiki with:
+- Overview of pgxkit
+- Navigation to other wiki pages
+- Quick start links
+
+### Suggested Initial Wiki Pages
+
+1. **Home** - Main landing page
+2. **Getting Started** - Quick start guide
+3. **API Reference** - Detailed API documentation
+4. **Performance Guide** - Performance optimization tips
+5. **Testing Guide** - Testing best practices
+6. **Production Guide** - Production deployment guide
+7. **Examples** - Code examples and use cases
+8. **FAQ** - Frequently asked questions
+9. **Contributing** - Contribution guidelines
+10. **Migration Guide** - Migration instructions between versions
+
+## Step 3: Wiki Permissions
+
+Configure wiki permissions:
+- Allow repository collaborators to edit the wiki
+- Consider if anonymous users should be able to view the wiki
+- Set up appropriate access controls
+
+## Step 4: Verification
+
+After setup, verify:
+- [ ] Wiki is accessible at `https://github.com/[username]/pgxkit/wiki`
+- [ ] Home page displays correctly
+- [ ] Team members can access and edit pages
+- [ ] Wiki navigation works properly
+
+## Next Steps
+
+After completing Phase 1:
+1. **Phase 2**: Restructure documentation into docs/ directory
+2. **Phase 3**: Implement automated wiki synchronization
+
+## Wiki Editing Guidelines
+
+### Markdown Standards
+- Use GitHub Flavored Markdown
+- Include syntax highlighting for code blocks
+- Use appropriate heading levels
+- Include table of contents for long pages
+
+### Content Organization
+- Keep pages focused and concise
+- Use cross-references between related pages
+- Maintain consistent formatting
+- Update navigation when adding new pages
+
+### Code Examples
+- Include complete, runnable examples
+- Add comments explaining key concepts
+- Test all code examples before publishing
+- Use realistic, practical examples
+
+## Troubleshooting
+
+### Common Issues
+- **Wiki not appearing**: Ensure it's enabled in repository settings
+- **Permission denied**: Check user permissions for the repository
+- **Formatting issues**: Verify markdown syntax and GitHub compatibility
+
+### Support
+If you encounter issues during setup, refer to:
+- GitHub documentation on Wikis
+- Repository issue tracker
+- Team communication channels 

--- a/wiki-templates/Home.md
+++ b/wiki-templates/Home.md
@@ -1,0 +1,83 @@
+# Welcome to pgxkit Wiki
+
+**pgxkit** is a lightweight, type-safe PostgreSQL toolkit for Go applications that provides a clean abstraction over pgx while maintaining performance and flexibility.
+
+## Quick Navigation
+
+### 📚 Documentation
+- [Getting Started](Getting-Started) - Setup and basic usage
+- [API Reference](API-Reference) - Complete API documentation
+- [Examples](Examples) - Practical code examples and use cases
+
+### 🚀 Performance & Production
+- [Performance Guide](Performance-Guide) - Optimization strategies and best practices
+- [Production Guide](Production-Guide) - Deployment and production considerations
+- [Testing Guide](Testing-Guide) - Testing strategies and golden tests
+
+### 🔧 Development
+- [Contributing](Contributing) - How to contribute to pgxkit
+- [Migration Guide](Migration-Guide) - Upgrading between versions
+- [FAQ](FAQ) - Frequently asked questions
+
+## Key Features
+
+- **Type-safe operations** with Go generics
+- **Connection pooling** with read/write splitting
+- **Golden testing** for reliable test suites
+- **Extensible hooks** for monitoring and logging
+- **Production-ready** with graceful shutdown
+- **Zero dependencies** beyond pgx
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+    
+    "github.com/nhalm/pgxkit"
+)
+
+func main() {
+    // Connect to database
+    db := pgxkit.NewDB()
+    err := db.Connect(context.Background(), "postgres://user:pass@localhost/db")
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer db.Close()
+    
+    // Execute a query
+    var name string
+    err = db.QueryRow(context.Background(), 
+        "SELECT name FROM users WHERE id = $1", 1).Scan(&name)
+    if err != nil {
+        log.Fatal(err)
+    }
+    
+    log.Printf("User name: %s", name)
+}
+```
+
+## Repository Information
+
+- **GitHub**: [https://github.com/nhalm/pgxkit](https://github.com/nhalm/pgxkit)
+- **Go Module**: `github.com/nhalm/pgxkit`
+- **License**: MIT
+- **Go Version**: 1.21+
+
+## Community
+
+- [Issues](https://github.com/nhalm/pgxkit/issues) - Report bugs or request features
+- [Discussions](https://github.com/nhalm/pgxkit/discussions) - Community discussions
+- [Pull Requests](https://github.com/nhalm/pgxkit/pulls) - Contribute code
+
+## Recent Updates
+
+This wiki is actively maintained and synchronized with the repository documentation. Check the [repository releases](https://github.com/nhalm/pgxkit/releases) for the latest updates.
+
+---
+
+*Last updated: [Auto-generated timestamp will be inserted here during sync]* 


### PR DESCRIPTION
## Summary

This PR adds the necessary documentation and templates to support **Phase 1: Enable GitHub Wiki** (Issue #25).

## Changes Made

- ✅ **WIKI_SETUP.md**: Comprehensive step-by-step guide for enabling GitHub Wiki
- ✅ **wiki-templates/Home.md**: Template for the initial wiki home page
- ✅ **README.md**: Added Documentation section with links to future wiki pages

## What This Enables

While the actual wiki enablement requires admin access to repository settings, this PR provides:

1. **Clear instructions** for repository administrators to enable the wiki
2. **Ready-to-use template** for the home page once wiki is enabled
3. **Updated README** that will automatically link to wiki pages once they exist
4. **Foundation** for Phase 2 (documentation restructuring) and Phase 3 (automated sync)

## Next Steps

After this PR is merged:
1. Repository admin enables wiki feature in GitHub settings
2. Copy wiki-templates/Home.md content to the wiki home page
3. Verify wiki functionality and permissions
4. Proceed to Phase 2: Restructure documentation into docs/ directory

## Testing

- [x] Documentation files are well-formatted
- [x] Links in README.md point to correct wiki URLs
- [x] Wiki setup guide covers all necessary steps
- [x] Home page template includes all key information

Addresses #25