### PR TITLE
Improve wiki sync trigger to handle merged PRs

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -6,6 +6,12 @@ on:
       - main
     paths:
       - "wiki/**"
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+    paths:
+      - "wiki/**"
   gollum:
 
 env:
@@ -16,7 +22,7 @@ jobs:
   sync-docs-to-wiki:
     name: Sync Documentation to Wiki
     runs-on: ubuntu-latest
-    if: github.event_name != 'gollum'
+    if: github.event_name != 'gollum' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true))
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The current wiki sync workflow only triggers on direct pushes to main. When PRs modifying wiki content are merged via GitHub UI, the workflow may not trigger reliably.

## Current Behavior

- ✅ Direct push to main → Wiki sync runs
- ❌ **PR merged to main** → Wiki sync may not run  
- ✅ Wiki edited directly → Reverse sync runs

## Solution

### Added Pull Request Trigger

```yaml
pull_request:
  types: [closed]
  branches:
    - main
  paths:
    - "wiki/**"
```

### Updated Job Condition

```yaml
if: github.event_name != 'gollum' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true))
```

## New Behavior

- ✅ Direct push to main → Wiki sync runs
- ✅ **PR merged to main** → Wiki sync runs (new)
- ❌ PR closed without merge → No action (correct)
- ✅ Wiki edited directly → Reverse sync runs

## Testing

When this PR is merged, it should trigger the wiki sync workflow and populate the GitHub Wiki with all documentation content.

## Benefits

1. **Robust Documentation Updates** - Wiki stays in sync regardless of how changes are made
2. **Standard PR Workflow** - Supports normal development process  
3. **No False Triggers** - Only runs when PRs are actually merged
4. **Maintains Existing Behavior** - Direct pushes continue to work

Resolves #35

## Next Steps

After merge, all future PRs that modify `wiki/**` files will automatically sync to the GitHub Wiki when merged.