### PR TITLE
Add automated wiki sync workflow

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -6,6 +6,12 @@ on:
       - main
     paths:
       - "wiki/**"
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+    paths:
+      - "wiki/**"
   gollum:
 
 env:
@@ -16,7 +22,7 @@ jobs:
   sync-docs-to-wiki:
     name: Sync Documentation to Wiki
     runs-on: ubuntu-latest
-    if: github.event_name != 'gollum'
+    if: github.event_name != 'gollum' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true))
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,61 @@
+name: Sync Documentation to Wiki
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'wiki/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout wiki repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: wiki
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: master
+
+      - name: Copy documentation files to wiki
+        run: |
+          # Preserve wiki-specific files (sidebar, footer, etc.)
+          find wiki/ -name "*.md" ! -name "_*.md" -delete
+          
+          # Copy all markdown files from wiki/ directory to wiki root
+          if [ -d "wiki" ]; then
+            find wiki/ -name "*.md" -exec cp {} wiki/ \;
+          fi
+          
+          # List files for verification
+          echo "Wiki files after sync:"
+          ls -la wiki/ | grep -E "\.(md)$" | sort
+
+      - name: Commit and push to wiki
+        run: |
+          cd wiki
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Auto-sync documentation from main repository
+
+            Updated: $(date -u +'%Y-%m-%d %H:%M:%S UTC')
+            Source: ${{ github.sha }}
+            Triggered by: ${{ github.event_name }}"
+            git push origin master
+          fi 


### PR DESCRIPTION
## Description
Implements automated synchronization of documentation from the main repository to the GitHub wiki.

## Changes
- Added `.github/workflows/wiki-sync.yml` workflow
- Triggers on pushes to main branch affecting `docs/**` and `wiki/**` paths
- Supports manual workflow dispatch
- Preserves wiki-specific files (`_Sidebar.md`, `_Footer.md`, etc.)
- Commits changes with descriptive messages including source SHA

## How it works
1. **Trigger**: Runs on pushes to main that modify documentation files
2. **Checkout**: Gets both main repo and wiki repo
3. **Sync**: Copies markdown files from `wiki/` directory to wiki root
4. **Preserve**: Keeps wiki-specific files intact
5. **Commit**: Only commits if there are actual changes

## Benefits
- ✅ Single source of truth for documentation
- ✅ Automatic wiki updates without manual intervention
- ✅ Preserves wiki-specific navigation files
- ✅ Clean commit history with detailed messages
- ✅ No unnecessary commits when no changes exist

## Testing
- Can be tested manually using workflow_dispatch
- Will automatically sync when wiki files are modified

Fixes #37