### PR TITLE
Refactor TestDB to match NewDB() connection pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,12 +220,19 @@ if err := db.HealthCheck(ctx); err != nil {
 ```go
 func TestUserOperations(t *testing.T) {
     testDB := pgxkit.NewTestDB()
-    err := testDB.Setup()
+    ctx := context.Background()
+    err := testDB.Connect(ctx, "") // Uses TEST_DATABASE_URL env var
     if err != nil {
         t.Skip("Test database not available")
     }
+    defer testDB.Shutdown(ctx)
+
+    err = testDB.Setup()
+    if err != nil {
+        t.Skip("Test database setup failed")
+    }
     defer testDB.Clean()
-    
+
     // Use testDB.DB for your tests
     _, err = testDB.Exec(ctx, "INSERT INTO users ...")
     // ... test assertions
@@ -237,12 +244,19 @@ func TestUserOperations(t *testing.T) {
 ```go
 func TestUserQueries(t *testing.T) {
     testDB := pgxkit.NewTestDB()
+    ctx := context.Background()
+    err := testDB.Connect(ctx, "")
+    if err != nil {
+        t.Skip("Test database not available")
+    }
+    defer testDB.Shutdown(ctx)
+
     testDB.Setup()
     defer testDB.Clean()
-    
+
     // Enable golden test hooks - captures EXPLAIN plans automatically
     db := testDB.EnableGolden(t, "TestUserQueries")
-    
+
     // These queries will have their EXPLAIN plans captured
     rows, err := db.Query(ctx, "SELECT * FROM users WHERE active = true")
     // ... more queries

--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -537,7 +537,23 @@ Testing utilities for database operations in tests.
 func NewTestDB() *TestDB
 ```
 
-Creates a new test database instance with testing utilities.
+Creates a new unconnected test database instance with testing utilities. Call `Connect()` to establish the database connection.
+
+**Example:**
+```go
+func TestUserQueries(t *testing.T) {
+    testDB := pgxkit.NewTestDB()
+    ctx := context.Background()
+    err := testDB.Connect(ctx, "") // Uses TEST_DATABASE_URL env var
+    if err != nil {
+        t.Skip("Test database not available:", err)
+    }
+    defer testDB.Shutdown(ctx)
+
+    // Or connect with explicit DSN:
+    // err := testDB.Connect(ctx, "postgres://user:pass@localhost/testdb")
+}
+```
 
 ### EnableGolden
 
@@ -551,8 +567,15 @@ Enables golden testing to capture and compare query execution plans for performa
 ```go
 func TestUserQueries(t *testing.T) {
     testDB := pgxkit.NewTestDB()
+    ctx := context.Background()
+    err := testDB.Connect(ctx, "")
+    if err != nil {
+        t.Skip("Test database not available:", err)
+    }
+    defer testDB.Shutdown(ctx)
+
     db := testDB.EnableGolden(t, "TestUserQueries")
-    
+
     // Queries will have their EXPLAIN plans captured
     rows, err := db.Query(ctx, "SELECT * FROM users WHERE active = true")
     // ...

--- a/test_db_test.go
+++ b/test_db_test.go
@@ -19,10 +19,9 @@ func TestNewTestDB(t *testing.T) {
 		t.Error("TestDB should wrap a valid DB instance")
 	}
 
-	// If no test database is available, writePool will be nil
-	if testDB.writePool == nil {
-		t.Skip("TEST_DATABASE_URL not set, skipping test")
-		return
+	// New pattern: TestDB should be unconnected initially
+	if testDB.writePool != nil {
+		t.Error("NewTestDB should return unconnected instance")
 	}
 }
 


### PR DESCRIPTION
## Summary

Refactors `NewTestDB()` to return an unconnected instance, requiring an explicit `Connect(ctx, dsn)` call. This matches the `NewDB()` pattern and provides flexibility to pass DSN directly without relying on environment variables.

## Breaking Change

⚠️ **BREAKING CHANGE**: `NewTestDB()` now returns an unconnected instance.

### Before:
```go
testDB := pgxkit.NewTestDB()
// Automatically connected using TEST_DATABASE_URL
```

### After:
```go
testDB := pgxkit.NewTestDB()
err := testDB.Connect(ctx, "") // uses TEST_DATABASE_URL
// or
err := testDB.Connect(ctx, "postgres://user:pass@localhost/testdb")
```

## Changes

- `NewTestDB()` returns unconnected TestDB instance
- `RequireDB()` helper updated to check `TEST_DATABASE_URL` and connect
- Updated all tests to use new connection pattern
- Updated documentation:
  - `Testing-Guide.md`
  - `API-Reference.md`
  - `README.md`

## Benefits

1. **Consistent API**: Matches `NewDB()` pattern exactly
2. **Flexibility**: Pass DSN directly without env vars
3. **Better control**: Explicit connection management in tests

## Testing

All tests pass:
```
go test -v ./...
```

Tests properly skip when `TEST_DATABASE_URL` is not set.

Closes #45