### PR TITLE
feat: extend golden testing to support INSERT, UPDATE, DELETE queries

### DIFF
--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -606,10 +606,10 @@ func TestUserQueries(t *testing.T) {
 ### EnableGolden
 
 ```go
-func (tdb *TestDB) EnableGolden(t *testing.T, testName string) *DB
+func (tdb *TestDB) EnableGolden(testName string) *DB
 ```
 
-Enables golden testing to capture and compare query execution plans for performance regression detection.
+Enables golden testing to capture and compare query execution plans for performance regression detection. Supports SELECT, INSERT, UPDATE, and DELETE queries. DML operations are executed within a transaction that is rolled back to avoid side effects.
 
 **Example:**
 ```go
@@ -622,11 +622,14 @@ func TestUserQueries(t *testing.T) {
     }
     defer testDB.Shutdown(ctx)
 
-    db := testDB.EnableGolden(t, "TestUserQueries")
+    db := testDB.EnableGolden("TestUserQueries")
 
-    // Queries will have their EXPLAIN plans captured
+    // SELECT queries have their EXPLAIN plans captured
     rows, err := db.Query(ctx, "SELECT * FROM users WHERE active = true")
     // ...
+
+    // DML queries are also captured (rolled back after EXPLAIN)
+    db.Exec(ctx, "UPDATE users SET last_login = NOW() WHERE id = $1", userID)
 }
 ```
 

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -246,7 +246,7 @@ Use golden tests for query plan regression detection:
 ```go
 func TestComplexQuery_Golden(t *testing.T) {
     testDB := setupTestDB(t)
-    db := testDB.EnableGolden(t, "TestComplexQuery")
+    db := testDB.EnableGolden("TestComplexQuery")
     
     // Query plan will be captured and compared
     rows, err := db.Query(ctx, complexQuery)

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -278,15 +278,17 @@ func advancedHealthCheck(db *pgxkit.DB) error {
 
 ### Golden Tests
 
+Golden tests capture EXPLAIN plans for SELECT, INSERT, UPDATE, and DELETE queries. DML operations are safely executed in rolled-back transactions.
+
 ```go
 func TestUserQueries(t *testing.T) {
     // Setup test database with golden test support
     testDB := pgxkit.NewTestDB(t)
-    db := testDB.EnableGolden(t, "TestUserQueries")
-    
+    db := testDB.EnableGolden("TestUserQueries")
+
     // Create test data
     testDB.LoadFixtures(t, "users.sql")
-    
+
     // Execute query - EXPLAIN plan will be captured
     rows, err := db.Query(context.Background(), `
         SELECT u.id, u.name, COUNT(o.id) as order_count

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -256,12 +256,12 @@ func NewTestSuite(t *testing.T) *TestSuite {
 
 ### What are golden tests and when should I use them?
 
-Golden tests capture and compare query execution plans to detect performance regressions:
+Golden tests capture and compare query execution plans for SELECT, INSERT, UPDATE, and DELETE queries to detect performance regressions. DML operations are executed in rolled-back transactions to avoid side effects:
 
 ```go
 func TestComplexQuery_Golden(t *testing.T) {
     testDB := setupTestDB(t)
-    db := testDB.EnableGolden(t, "TestComplexQuery")
+    db := testDB.EnableGolden("TestComplexQuery")
     
     // Query plan will be captured automatically
     rows, err := db.Query(ctx, `
@@ -277,8 +277,9 @@ func TestComplexQuery_Golden(t *testing.T) {
 ```
 
 **Use golden tests for:**
-- Critical queries that must maintain performance
+- Critical SELECT queries that must maintain performance
 - Complex queries with multiple joins
+- INSERT/UPDATE/DELETE operations with complex WHERE clauses
 - Queries that use indexes heavily
 - Performance regression detection in CI/CD
 

--- a/docs/Performance-Guide.md
+++ b/docs/Performance-Guide.md
@@ -537,14 +537,16 @@ func setupPerformanceMonitoring(db *pgxkit.DB, metrics *PerformanceMetrics) {
 
 ## Golden Testing for Performance
 
+Golden testing captures EXPLAIN (ANALYZE, BUFFERS) plans for SELECT, INSERT, UPDATE, and DELETE queries. DML operations are executed within a rolled-back transaction to avoid side effects.
+
 ### Automated Performance Regression Detection
 
 ```go
 func TestQueryPerformance(t *testing.T) {
     testDB := setupTestDB(t)
-    
+
     // Enable golden testing to capture EXPLAIN plans
-    db := testDB.EnableGolden(t, "TestQueryPerformance")
+    db := testDB.EnableGolden("TestQueryPerformance")
     
     // Create test data
     createTestData(t, testDB, 10000)


### PR DESCRIPTION
## Summary

- Golden testing now captures EXPLAIN plans for INSERT, UPDATE, DELETE queries (not just SELECT)
- DML operations are executed within a transaction that is rolled back, so no data is modified
- Includes CTE support (`WITH ... INSERT/UPDATE/DELETE`)

## Changes

- Add DML detection (INSERT/UPDATE/DELETE) in `captureExplainPlan`
- Wrap DML EXPLAIN in transaction with rollback for safety
- Handle CTEs by finding terminal statement type using `LastIndex`
- Fix race condition in `appendToGoldenFile` with mutex protection
- Add `rows.Err()` checks after iteration
- Handle JSON unmarshal errors in golden file parsing
- Add `toFloat64` helper for robust timing value extraction
- Fix `EnableGolden` signature in all documentation
- Add unit tests for DML and CTE golden testing

## Test plan

- [x] Build passes
- [x] All tests pass
- [x] Lint clean (0 issues)
- [x] Unit tests for INSERT, UPDATE, DELETE
- [x] Unit tests for CTE queries

Closes #50