### PR TITLE
feat: Makefile-driven local + CI test workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,43 +12,28 @@ jobs:
   benchmark:
     name: Performance Regression Check
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:15
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: testdb
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-    
+
     steps:
     - uses: actions/checkout@v6
-    
+
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
         go-version: '1.26'
-    
+
     - name: Run benchmarks
-      run: go test -bench=. -benchmem -run=^$ ./...
-      env:
-        TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/testdb?sslmode=disable
-    
-    - name: Run hook overhead benchmark
+      run: make bench | tee bench.out
+
+    - name: Surface results in summary
+      if: always()
       run: |
-        echo "## Hook Overhead Benchmark" >> $GITHUB_STEP_SUMMARY
-        go test -bench=BenchmarkHookOverhead -benchmem -run=^$ ./... | tee -a $GITHUB_STEP_SUMMARY
-      env:
-        TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/testdb?sslmode=disable
-    
-    - name: Run pool operations benchmark
-      run: |
-        echo "## Pool Operations Benchmark" >> $GITHUB_STEP_SUMMARY
-        go test -bench=BenchmarkPoolOperations -benchmem -run=^$ ./... | tee -a $GITHUB_STEP_SUMMARY
-      env:
-        TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/testdb?sslmode=disable 
+        {
+          echo "## Benchmark Results"
+          echo '```'
+          cat bench.out
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Tear down test database
+      if: always()
+      run: make test-db-down

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,12 @@ jobs:
     - name: Verify dependencies
       run: go mod verify
 
-    - name: Run tests
-      run: go test -v -race -parallel=1 ./...
-
     - name: Run tests with coverage
-      run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
+      run: make test-coverage
+
+    - name: Tear down test database
+      if: always()
+      run: make test-db-down
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v6
@@ -108,34 +109,3 @@ jobs:
 
     - name: Build
       run: go build -v ./...
-
-  integration-test:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    needs: [test, lint]
-    services:
-      postgres:
-        image: postgres:15
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: testdb
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
-    steps:
-    - uses: actions/checkout@v6
-
-    - name: Set up Go
-      uses: actions/setup-go@v6
-      with:
-        go-version: '1.26'
-
-    - name: Run integration tests
-      run: go test -v -tags=integration -parallel=1 ./...
-      env:
-        DATABASE_URL: postgres://postgres:postgres@localhost:5432/testdb?sslmode=disable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# CLAUDE.md
+
+Repo-specific guidance for Claude Code sessions working in pgxkit.
+
+## Always use the Makefile
+
+The `Makefile` is the canonical entry point for tests, lint, and benchmarks —
+locally and in CI. Do **not** invoke `go test`, `golangci-lint`, or
+`docker compose` directly.
+
+| Task                | Use                  |
+| ------------------- | -------------------- |
+| Run the test suite  | `make test`          |
+| Run with coverage   | `make test-coverage` |
+| Run benchmarks      | `make bench`         |
+| Run the linter      | `make lint`          |
+| Start the test DB   | `make test-db-up`    |
+| Stop the test DB    | `make test-db-down`  |
+| List all targets    | `make help`          |
+
+The DB targets use `docker-compose.yml` and let Docker assign a free host port
+(no fixed 5432) to avoid clashes with any local Postgres. `make test` and
+friends discover that port at runtime and inject `TEST_DATABASE_URL`.
+
+If a target you need doesn't exist, add it to the `Makefile` rather than
+running the underlying command ad-hoc — that's how local and CI drift apart.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+# Canonical entry point for local development and CI. All test/lint/bench
+# invocations should go through these targets so local and CI stay in sync.
+
+COMPOSE_PROJECT ?= pgxkit-test
+DOCKER_COMPOSE  := docker compose -p $(COMPOSE_PROJECT)
+
+# Resolved lazily (recursive `=`) so it's only computed when a recipe needs it,
+# after `test-db-up` has run and the container is listening.
+TEST_DB_PORT      = $(shell $(DOCKER_COMPOSE) port postgres 5432 2>/dev/null | awk -F: '{print $$NF}')
+TEST_DATABASE_URL = postgres://postgres:postgres@localhost:$(TEST_DB_PORT)/testdb?sslmode=disable
+
+GO_TEST_FLAGS ?= -v -race -parallel=1
+
+.PHONY: help test-db-up test-db-down test test-coverage coverage-html lint bench
+
+help: ## Show available targets
+	@awk 'BEGIN {FS = ":.*##"; printf "Targets:\n"} /^[a-zA-Z_-]+:.*?##/ {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+test-db-up: ## Start the test Postgres container (idempotent)
+	$(DOCKER_COMPOSE) up -d --wait
+	@echo "Postgres ready on host port $$($(DOCKER_COMPOSE) port postgres 5432 | awk -F: '{print $$NF}')"
+
+test-db-down: ## Stop the test Postgres container and remove its volume
+	$(DOCKER_COMPOSE) down -v
+
+test: test-db-up ## Run the full test suite against the local test DB
+	@TEST_DATABASE_URL="$(TEST_DATABASE_URL)" go test $(GO_TEST_FLAGS) ./...
+
+test-coverage: test-db-up ## Run the test suite and write coverage.out
+	@TEST_DATABASE_URL="$(TEST_DATABASE_URL)" go test $(GO_TEST_FLAGS) -coverprofile=coverage.out -covermode=atomic ./...
+
+coverage-html: ## Open coverage.out in the browser (run after test-coverage)
+	go tool cover -html=coverage.out
+
+lint: ## Run golangci-lint
+	golangci-lint run --timeout=5m
+
+bench: test-db-up ## Run benchmarks against the local test DB
+	@TEST_DATABASE_URL="$(TEST_DATABASE_URL)" go test -bench=. -benchmem -run=^$$ ./...

--- a/README.md
+++ b/README.md
@@ -247,6 +247,24 @@ if err := db.HealthCheck(ctx); err != nil {
 
 ## Testing
 
+### Running the Test Suite
+
+This repo uses a `Makefile` as the single entry point for tests, lint, and
+benchmarks — both locally and in CI. Always use the make targets so the two
+stay in sync.
+
+```bash
+make test-db-up    # start a containerized Postgres on a free host port
+make test          # run the full suite
+make test-db-down  # tear down when done
+```
+
+Other targets: `make test-coverage`, `make coverage-html`, `make bench`,
+`make lint`, `make help`.
+
+Requires Docker. To use an existing Postgres instead, set `TEST_DATABASE_URL`
+and run `go test ./...` directly.
+
 ### Basic Testing
 
 ```go

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: testdb
+    ports:
+      # No fixed host port — Docker assigns a free one to avoid 5432 conflicts.
+      # The Makefile discovers it via `docker compose port postgres 5432`.
+      - "5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 1s
+      timeout: 3s
+      retries: 30

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -19,10 +19,10 @@ Thank you for your interest in contributing to pgxkit! This guide will help you 
 
 ### Prerequisites
 
-- Go 1.21 or later
-- PostgreSQL 12 or later (for testing)
+- Go 1.25 or later
+- Docker (for the local test database)
 - Git
-- Make (optional, for convenience commands)
+- Make
 
 ### Repository Structure
 
@@ -53,40 +53,44 @@ cd pgxkit
 ### 2. Set Up Development Environment
 
 ```bash
-# Install dependencies
 go mod download
-
-# Set up test database
-export TEST_POSTGRES_HOST=localhost
-export TEST_POSTGRES_PORT=5432
-export TEST_POSTGRES_USER=postgres
-export TEST_POSTGRES_PASSWORD=yourpassword
-export TEST_POSTGRES_DB=pgxkit_test
-export TEST_POSTGRES_SSLMODE=disable
 ```
 
 ### 3. Run Tests
 
+The `Makefile` is the canonical entry point — it spins up a containerized
+Postgres, exports the right `TEST_DATABASE_URL`, and runs the suite the same
+way CI does. Always use it instead of invoking `go test` directly.
+
 ```bash
-# Run all tests
-go test ./...
-
-# Run tests with coverage
-go test -race -coverprofile=coverage.out ./...
-go tool cover -html=coverage.out
-
-# Run specific test
-go test -run TestSpecificFunction ./...
+make test-db-up    # start Postgres (Docker assigns a free host port)
+make test          # run the full suite
+make test-db-down  # tear down when done
 ```
+
+Other useful targets:
+
+```bash
+make test-coverage   # writes coverage.out
+make coverage-html   # open the HTML coverage report
+make bench           # run benchmarks
+make lint            # run golangci-lint
+make help            # list all targets
+```
+
+If you want to point the suite at an existing Postgres instance instead of the
+Docker one, set `TEST_DATABASE_URL` directly and run `go test ./...`.
 
 ### 4. Run Linting
 
 ```bash
-# Install golangci-lint if not already installed
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+make lint
+```
 
-# Run linting
-golangci-lint run
+Install `golangci-lint` first if you don't have it:
+
+```bash
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 ```
 
 ## Code Standards
@@ -261,12 +265,12 @@ func TestComplexQuery_Golden(t *testing.T) {
 
 1. **Run all tests locally**
    ```bash
-   go test ./...
+   make test
    ```
 
 2. **Run linting**
    ```bash
-   golangci-lint run
+   make lint
    ```
 
 3. **Update documentation** if needed

--- a/integration_test.go
+++ b/integration_test.go
@@ -156,7 +156,7 @@ func TestTransactionRollbackOnError(t *testing.T) {
 }
 
 func TestGracefulShutdownWaitsForTransaction(t *testing.T) {
-	pool := requireTestPool(t)
+	pool := newIsolatedTestPool(t)
 	ctx := context.Background()
 
 	db := NewDB()
@@ -167,7 +167,15 @@ func TestGracefulShutdownWaitsForTransaction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test table: %v", err)
 	}
-	defer CleanupTestData("DROP TABLE IF EXISTS tx_test_shutdown")
+	t.Cleanup(func() {
+		shared := getTestPool()
+		if shared == nil {
+			return
+		}
+		if _, err := shared.Exec(context.Background(), "DROP TABLE IF EXISTS tx_test_shutdown"); err != nil {
+			t.Logf("cleanup DROP TABLE failed: %v", err)
+		}
+	})
 
 	tx, err := db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
@@ -205,8 +213,9 @@ func TestGracefulShutdownWaitsForTransaction(t *testing.T) {
 		t.Fatal("Shutdown did not complete after transaction finished")
 	}
 
+	verifyPool := requireTestPool(t)
 	var value string
-	err = pool.QueryRow(ctx, `SELECT value FROM tx_test_shutdown WHERE value = $1`, "during_shutdown").Scan(&value)
+	err = verifyPool.QueryRow(ctx, `SELECT value FROM tx_test_shutdown WHERE value = $1`, "during_shutdown").Scan(&value)
 	if err != nil {
 		t.Fatalf("Failed to verify committed data: %v", err)
 	}
@@ -216,10 +225,10 @@ func TestGracefulShutdownWaitsForTransaction(t *testing.T) {
 }
 
 func TestActiveOpsTracking(t *testing.T) {
-	pool := requireTestPool(t)
 	ctx := context.Background()
 
 	t.Run("increments on BeginTx and decrements on Commit", func(t *testing.T) {
+		pool := newIsolatedTestPool(t)
 		db := NewDB()
 		db.readPool = pool
 		db.writePool = pool
@@ -256,6 +265,7 @@ func TestActiveOpsTracking(t *testing.T) {
 	})
 
 	t.Run("increments on BeginTx and decrements on Rollback", func(t *testing.T) {
+		pool := newIsolatedTestPool(t)
 		db := NewDB()
 		db.readPool = pool
 		db.writePool = pool

--- a/test_connection.go
+++ b/test_connection.go
@@ -66,6 +66,32 @@ func requireTestPool(t *testing.T) *pgxpool.Pool {
 	return pool
 }
 
+// newIsolatedTestPool returns a fresh pool that the test owns. Use this when
+// the test needs to call Close/Shutdown — borrowing the shared pool from
+// requireTestPool would close it for every later test.
+func newIsolatedTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("TEST_DATABASE_URL not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+	config, err := pgxpool.ParseConfig(dbURL)
+	if err != nil {
+		t.Fatalf("Failed to parse TEST_DATABASE_URL: %v", err)
+	}
+	config.MaxConns = 5
+	config.MinConns = 1
+
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatalf("Failed to create isolated test pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
 // CleanupTestData executes cleanup SQL statements on the shared test database
 func CleanupTestData(sqlStatements ...string) {
 	pool := getTestPool()

--- a/test_db.go
+++ b/test_db.go
@@ -153,18 +153,21 @@ func (g *goldenTestHook) captureExplainPlan(ctx context.Context, sql string, arg
 		return nil
 	}
 
-	upperSQL := strings.ToUpper(strings.TrimSpace(sql))
+	// Collapse runs of whitespace to single spaces so token boundary searches
+	// (`" SELECT "` etc.) match across raw-string SQL that contains tabs and
+	// newlines around keywords.
+	upperSQL := " " + strings.Join(strings.Fields(strings.ToUpper(sql)), " ") + " "
 
-	if strings.HasPrefix(upperSQL, "EXPLAIN") {
+	if strings.HasPrefix(upperSQL, " EXPLAIN ") {
 		return nil
 	}
 
-	isSelect := strings.HasPrefix(upperSQL, "SELECT")
-	isDML := strings.HasPrefix(upperSQL, "INSERT") ||
-		strings.HasPrefix(upperSQL, "UPDATE") ||
-		strings.HasPrefix(upperSQL, "DELETE")
+	isSelect := strings.HasPrefix(upperSQL, " SELECT ")
+	isDML := strings.HasPrefix(upperSQL, " INSERT ") ||
+		strings.HasPrefix(upperSQL, " UPDATE ") ||
+		strings.HasPrefix(upperSQL, " DELETE ")
 
-	if strings.HasPrefix(upperSQL, "WITH") {
+	if strings.HasPrefix(upperSQL, " WITH ") {
 		lastSelect := strings.LastIndex(upperSQL, " SELECT ")
 		lastInsert := strings.LastIndex(upperSQL, " INSERT ")
 		lastUpdate := strings.LastIndex(upperSQL, " UPDATE ")

--- a/test_db_test.go
+++ b/test_db_test.go
@@ -178,17 +178,22 @@ func TestGoldenDML(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Create a temporary table for DML testing
+	// Use a regular table (not TEMP) so it's visible across pool connections —
+	// EnableGolden returns a *DB sharing the pool, and DML may execute on a
+	// different connection than the CREATE.
 	_, err := testDB.Exec(ctx, `
-		CREATE TEMP TABLE golden_test_users (
+		CREATE TABLE IF NOT EXISTS golden_test_users (
 			id SERIAL PRIMARY KEY,
 			name TEXT NOT NULL,
 			email TEXT
 		)
 	`)
 	if err != nil {
-		t.Fatalf("Failed to create temp table: %v", err)
+		t.Fatalf("Failed to create test table: %v", err)
 	}
+	t.Cleanup(func() {
+		_, _ = testDB.Exec(context.Background(), "DROP TABLE IF EXISTS golden_test_users")
+	})
 
 	t.Run("insert", func(t *testing.T) {
 		goldenDB := testDB.EnableGolden("TestGoldenDML_Insert")
@@ -251,16 +256,19 @@ func TestGoldenCTE(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Create temp table
+	// Regular table — see TestGoldenDML for why TEMP doesn't work here.
 	_, err := testDB.Exec(ctx, `
-		CREATE TEMP TABLE golden_cte_test (
+		CREATE TABLE IF NOT EXISTS golden_cte_test (
 			id SERIAL PRIMARY KEY,
 			value INT
 		)
 	`)
 	if err != nil {
-		t.Fatalf("Failed to create temp table: %v", err)
+		t.Fatalf("Failed to create test table: %v", err)
 	}
+	t.Cleanup(func() {
+		_, _ = testDB.Exec(context.Background(), "DROP TABLE IF EXISTS golden_cte_test")
+	})
 
 	t.Run("cte_select", func(t *testing.T) {
 		goldenDB := testDB.EnableGolden("TestGoldenCTE_Select")


### PR DESCRIPTION
Closes #70

## Summary

- Adds `docker-compose.yml` (postgres:15) and a `Makefile` as the single entry point for tests, lint, and benchmarks — both locally and in CI.
- Docker assigns a free host port (no fixed 5432) to avoid clashes with any local Postgres; the Makefile discovers the port at runtime and injects `TEST_DATABASE_URL`.
- CI now calls the same `make` targets, so local and CI cannot drift.
- README, `docs/Contributing.md`, and a new `CLAUDE.md` mandate Makefile usage and drop the stale `TEST_POSTGRES_*` instructions.

## Bugs surfaced and fixed

The integration suite had been silently skipping in CI for a long time (CI set `DATABASE_URL` but the code reads `TEST_DATABASE_URL`). Running it against a real DB locally surfaced three latent bugs:

1. **Shared-pool pollution** — `TestGracefulShutdownWaitsForTransaction` and `TestActiveOpsTracking` called `db.Shutdown()` on the shared test pool, closing it for every later test. Added a `newIsolatedTestPool` helper for tests with destructive lifecycles.
2. **Temp-table assumption** — `TestGoldenDML` / `TestGoldenCTE` used `CREATE TEMP TABLE`, but `EnableGolden` returns a `*DB` sharing the same pool, so DML executed on a different connection where the temp table didn't exist. Switched to regular tables with cleanup.
3. **Production bug in `goldenTestHook.captureExplainPlan`** — CTE keyword detection used `" SELECT "` literal-space tokens against raw-string SQL containing tabs and newlines, so the hook never recognized any CTE and silently produced no golden file. Normalize whitespace before token searches.

## Test plan

- [x] `make test-db-up && make test && make test-db-down` runs green on a fresh state.
- [x] `git status` is clean after `make test-db-down`.
- [x] `make lint` passes (0 issues).
- [x] `make bench` runs without errors.
- [ ] CI run on this PR is green.