### PR TITLE
feat: add transcript-based golden testing (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,6 @@ func TestCreateOrder(t *testing.T) {
         t.Skip("Test database not available")
     }
     defer testDB.Shutdown(ctx)
-    defer pgxkit.CleanupGolden("TestCreateOrder")
 
     // Captures BEGIN/QUERY/COMMIT/ROLLBACK events with normalized args and rows.
     golden := testDB.EnableGolden("TestCreateOrder")

--- a/README.md
+++ b/README.md
@@ -318,6 +318,30 @@ func TestUserQueries(t *testing.T) {
 }
 ```
 
+### Golden Transcript Testing
+
+```go
+func TestCreateOrder(t *testing.T) {
+    testDB := pgxkit.NewTestDB()
+    ctx := context.Background()
+    err := testDB.Connect(ctx, "")
+    if err != nil {
+        t.Skip("Test database not available")
+    }
+    defer testDB.Shutdown(ctx)
+    defer pgxkit.CleanupGolden("TestCreateOrder")
+
+    // Captures BEGIN/QUERY/COMMIT/ROLLBACK events with normalized args and rows.
+    golden := testDB.EnableGolden("TestCreateOrder")
+
+    // ... call the code under test using golden as the DB ...
+
+    // Writes testdata/golden/TestCreateOrder.json on first run; diffs the
+    // transcript on subsequent runs. Use `go test -overwrite-golden` to refresh.
+    golden.AssertGolden(t, "TestCreateOrder")
+}
+```
+
 ## Type Helpers
 
 Seamless conversions between Go types and pgx types:

--- a/db.go
+++ b/db.go
@@ -176,6 +176,7 @@ type DB struct {
 	readPool  *pgxpool.Pool
 	writePool *pgxpool.Pool
 	hooks     *hooks
+	recorder  *transcriptRecorder
 	mu        sync.RWMutex
 	shutdown  bool
 	activeOps sync.WaitGroup
@@ -616,8 +617,12 @@ func (db *DB) BeginTx(ctx context.Context, txOptions pgx.TxOptions) (*Tx, error)
 		return nil, err
 	}
 
+	if db.recorder != nil {
+		db.recorder.recordBegin()
+	}
+
 	db.activeOps.Add(1)
-	return &Tx{tx: pgxTx, db: db}, nil
+	return &Tx{tx: pgxTx, db: db, recorder: db.recorder}, nil
 }
 
 // Shutdown gracefully shuts down the database connections.
@@ -790,6 +795,14 @@ func (db *DB) executeQuery(ctx context.Context, pool *pgxpool.Pool, sql string, 
 		}
 	}
 
+	if err == nil && db.recorder != nil && rows != nil {
+		replay, recordErr := captureRowsForGolden(rows, db.recorder, sql, args)
+		if recordErr != nil {
+			return nil, recordErr
+		}
+		return replay, nil
+	}
+
 	return rows, err
 }
 
@@ -810,6 +823,24 @@ func (db *DB) executeQueryRow(ctx context.Context, pool *pgxpool.Pool, sql strin
 
 	if err := db.hooks.executeBeforeOperation(ctx, sql, args, nil); err != nil {
 		return &shutdownRow{err: fmt.Errorf("before operation hook failed: %w", err)}
+	}
+
+	if db.recorder != nil {
+		rows, qerr := pool.Query(ctx, sql, args...)
+		if hookErr := db.hooks.executeAfterOperation(ctx, sql, args, qerr); hookErr != nil {
+			if rows != nil {
+				rows.Close()
+			}
+			return &shutdownRow{err: fmt.Errorf("after operation hook failed: %w", hookErr)}
+		}
+		if qerr != nil {
+			return &shutdownRow{err: qerr}
+		}
+		replay, recordErr := captureRowsForGolden(rows, db.recorder, sql, args)
+		if recordErr != nil {
+			return &shutdownRow{err: recordErr}
+		}
+		return &replayRow{rows: replay}
 	}
 
 	row := pool.QueryRow(ctx, sql, args...)
@@ -846,6 +877,10 @@ func (db *DB) executeExec(ctx context.Context, pool *pgxpool.Pool, sql string, a
 		if err == nil {
 			return tag, fmt.Errorf("after operation hook failed: %w", hookErr)
 		}
+	}
+
+	if err == nil && db.recorder != nil {
+		db.recorder.recordExec(sql, args, tag.RowsAffected())
 	}
 
 	return tag, err

--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -853,6 +853,59 @@ func TestUserQueries(t *testing.T) {
 }
 ```
 
+### EnableGolden
+
+```go
+func (tdb *TestDB) EnableGolden(testName string, opts ...GoldenOption) *DB
+```
+
+Enables golden transcript testing. Records every database event (BEGIN, QUERY, COMMIT, ROLLBACK) the scenario produces, along with the SQL, normalized args, and materialized result rows. Call `AssertGolden` after the scenario to compare the transcript against `testdata/golden/<testName>.json`. Volatile values (`time.Time`, UUIDs, integer columns named `id` or `*_id`) are normalized to stable placeholders so transcripts compare cleanly across runs.
+
+**Example:**
+```go
+func TestCreateOrder(t *testing.T) {
+    testDB := pgxkit.NewTestDB()
+    ctx := context.Background()
+    if err := testDB.Connect(ctx, ""); err != nil {
+        t.Skip("Test database not available:", err)
+    }
+    defer testDB.Shutdown(ctx)
+    defer pgxkit.CleanupGolden("TestCreateOrder")
+
+    golden := testDB.EnableGolden("TestCreateOrder")
+    // ... call the code under test using golden as the DB ...
+    golden.AssertGolden(t, "TestCreateOrder")
+}
+```
+
+Use `go test -overwrite-golden` to regenerate baselines after intentional behavior changes.
+
+### GoldenOption / WithGoldenNormalizer
+
+```go
+type GoldenOption func(*transcriptRecorder)
+
+func WithGoldenNormalizer(fn func(any) (any, bool)) GoldenOption
+```
+
+`WithGoldenNormalizer` registers a custom normalizer that runs before pgxkit's defaults. Return `(replacement, true)` to take over normalization for the value; return `(nil, false)` to fall through to the next custom normalizer or to the defaults.
+
+### AssertGolden
+
+```go
+func (db *DB) AssertGolden(t *testing.T, testName string)
+```
+
+Compares the captured transcript against `testdata/golden/<testName>.json`. On the first run (or with the `-overwrite-golden` flag) it writes the baseline and logs that fact. On subsequent runs it fails the test with a unified diff if the transcript has changed. `testName` must match the name passed to `EnableGolden`.
+
+### CleanupGolden
+
+```go
+func CleanupGolden(testName string) error
+```
+
+Removes the golden transcript file for the named scenario from `testdata/golden/`. Tests that create golden files should defer this call to keep the repository clean of throwaway baselines.
+
 ## Utility Functions
 
 ### GetDSN

--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -870,7 +870,6 @@ func TestCreateOrder(t *testing.T) {
         t.Skip("Test database not available:", err)
     }
     defer testDB.Shutdown(ctx)
-    defer pgxkit.CleanupGolden("TestCreateOrder")
 
     golden := testDB.EnableGolden("TestCreateOrder")
     // ... call the code under test using golden as the DB ...
@@ -897,14 +896,6 @@ func (db *DB) AssertGolden(t *testing.T, testName string)
 ```
 
 Compares the captured transcript against `testdata/golden/<testName>.json`. On the first run (or with the `-overwrite-golden` flag) it writes the baseline and logs that fact. On subsequent runs it fails the test with a unified diff if the transcript has changed. `testName` must match the name passed to `EnableGolden`.
-
-### CleanupGolden
-
-```go
-func CleanupGolden(testName string) error
-```
-
-Removes the golden transcript file for the named scenario from `testdata/golden/`. Tests that create golden files should defer this call to keep the repository clean of throwaway baselines.
 
 ## Utility Functions
 

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -580,7 +580,6 @@ func TestCreateOrder(t *testing.T) {
         t.Skip("Test database not available")
     }
     defer testDB.Shutdown(ctx)
-    defer pgxkit.CleanupGolden("TestCreateOrder")
 
     golden := testDB.EnableGolden("TestCreateOrder")
 

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -567,6 +567,46 @@ func TestUserQueries(t *testing.T) {
 }
 ```
 
+### Golden Transcript Tests
+
+Golden tests capture the ordered sequence of database events a scenario produces (BEGIN, every Query/Exec with normalized args and rows, COMMIT/ROLLBACK) and assert on subsequent runs that nothing changed.
+
+```go
+func TestCreateOrder(t *testing.T) {
+    ctx := context.Background()
+
+    testDB := pgxkit.NewTestDB()
+    if err := testDB.Connect(ctx, ""); err != nil {
+        t.Skip("Test database not available")
+    }
+    defer testDB.Shutdown(ctx)
+    defer pgxkit.CleanupGolden("TestCreateOrder")
+
+    golden := testDB.EnableGolden("TestCreateOrder")
+
+    tx, err := golden.BeginTx(ctx, pgx.TxOptions{})
+    require.NoError(t, err)
+
+    var orderID int
+    err = tx.QueryRow(ctx, `
+        INSERT INTO orders (total) VALUES ($1) RETURNING id
+    `, 100).Scan(&orderID)
+    require.NoError(t, err)
+
+    _, err = tx.Exec(ctx, `
+        INSERT INTO order_items (order_id, sku, qty) VALUES ($1, $2, $3)
+    `, orderID, "SKU-1", 2)
+    require.NoError(t, err)
+
+    require.NoError(t, tx.Commit(ctx))
+
+    // First run writes testdata/golden/TestCreateOrder.json.
+    // Subsequent runs diff the transcript and fail on any change.
+    // Use `go test -overwrite-golden` to refresh after intentional changes.
+    golden.AssertGolden(t, "TestCreateOrder")
+}
+```
+
 ### Test Database Helper
 
 ```go

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -303,7 +303,6 @@ They answer different questions, and pgxkit ships both.
 ```go
 func TestCreateOrder(t *testing.T) {
     testDB := pgxkit.RequireDB(t)
-    defer pgxkit.CleanupGolden("TestCreateOrder")
 
     golden := testDB.EnableGolden("TestCreateOrder")
     // ... run the code under test using golden as the DB ...

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -292,6 +292,29 @@ func TestComplexQuery_Plan(t *testing.T) {
 - Queries that depend on specific index usage
 - Catching unintentional plan changes in CI/CD
 
+### When should I use Golden testing vs Plan-Regression testing?
+
+They answer different questions, and pgxkit ships both.
+
+**Plan-Regression (`EnableAssertPlan` / `AssertPlan`)** asserts the *structural query plan* — the shape returned by `EXPLAIN (FORMAT JSON, COSTS OFF)`. It catches plan changes such as a seq-scan replacing an index-scan, a nested-loop turning into a hash-join, or a different join order. It does not look at result rows.
+
+**Golden transcripts (`EnableGolden` / `AssertGolden`)** assert the *behavior* of a scenario — the ordered sequence of `BEGIN`, every `Query`/`Exec` (with SQL, normalized args, and materialized rows), and the closing `COMMIT` or `ROLLBACK`. It catches an extra UPDATE, a missing INSERT, a different argument, a different returned row, or a `COMMIT` that became a `ROLLBACK`.
+
+```go
+func TestCreateOrder(t *testing.T) {
+    testDB := pgxkit.RequireDB(t)
+    defer pgxkit.CleanupGolden("TestCreateOrder")
+
+    golden := testDB.EnableGolden("TestCreateOrder")
+    // ... run the code under test using golden as the DB ...
+    golden.AssertGolden(t, "TestCreateOrder")
+}
+```
+
+Volatile values (timestamps, UUIDs, sequence-style IDs) are normalized to placeholders so transcripts compare cleanly across runs. Use `go test -overwrite-golden` to refresh the baseline after intentional behavior changes.
+
+`EnableGolden` and `EnableAssertPlan` each return a fresh `*DB`, so they don't compose on a single instance — pick one per scenario depending on whether you need plan stability or behavioral stability.
+
 ### How do I test error conditions?
 
 Test various error scenarios to ensure robust error handling:

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -12,7 +12,7 @@
 ### Performance & Production
 - [Performance Guide](Performance-Guide) - Optimization strategies and best practices
 - [Production Guide](Production-Guide) - Deployment and production considerations
-- [Testing Guide](Testing-Guide) - Testing strategies and plan-regression tests
+- [Testing Guide](Testing-Guide) - Testing strategies, plan-regression, and golden transcript tests
 
 ### Development
 - [Contributing](Contributing) - How to contribute to pgxkit
@@ -23,6 +23,7 @@
 - **Type-safe operations** with Go generics
 - **Connection pooling** with read/write splitting
 - **Plan-regression testing** to catch query plan shape changes
+- **Golden transcript testing** to catch behavioral changes (extra/missing/reordered statements, different args, different rows)
 - **Extensible hooks** for monitoring and logging
 - **Production-ready** with graceful shutdown
 - **Zero dependencies** beyond pgx

--- a/docs/Testing-Guide.md
+++ b/docs/Testing-Guide.md
@@ -11,11 +11,12 @@ This guide covers effective testing strategies and best practices when using pgx
 3. [Unit Testing](#unit-testing)
 4. [Integration Testing](#integration-testing)
 5. [Plan-Regression Testing](#plan-regression-testing)
-6. [Testing Patterns](#testing-patterns)
-7. [Test Data Management](#test-data-management)
-8. [Performance Testing](#performance-testing)
-9. [Error Testing](#error-testing)
-10. [Best Practices](#best-practices)
+6. [Golden Transcript Testing](#golden-transcript-testing)
+7. [Testing Patterns](#testing-patterns)
+8. [Test Data Management](#test-data-management)
+9. [Performance Testing](#performance-testing)
+10. [Error Testing](#error-testing)
+11. [Best Practices](#best-practices)
 
 ## Testing Philosophy
 
@@ -562,6 +563,85 @@ func TestPerformanceRegression(t *testing.T) {
 }
 ```
 
+## Golden Transcript Testing
+
+Golden transcript testing is a behavioral assertion: it captures the full sequence of database events a scenario produces — `BEGIN`, every `Query`/`Exec` with its SQL, normalized args, and materialized result rows, and the closing `COMMIT` or `ROLLBACK` — and asserts on subsequent runs that the transcript hasn't changed. It catches an extra UPDATE, a missing INSERT, a different argument, a different returned row, or a `COMMIT` becoming a `ROLLBACK`.
+
+This complements [Plan-Regression Testing](#plan-regression-testing): plan-regression catches changes to query plan *shape*, golden transcripts catch changes to *behavior*. Use one or the other per scenario — `EnableGolden` and `EnableAssertPlan` each return a fresh `*DB`, so they don't compose on the same instance.
+
+### Basic Usage
+
+```go
+func TestCreateOrder(t *testing.T) {
+    testDB := pgxkit.RequireDB(t)
+    defer pgxkit.CleanupGolden("TestCreateOrder")
+
+    golden := testDB.EnableGolden("TestCreateOrder")
+
+    // run the code under test using golden as the DB
+    _, err := golden.Exec(context.Background(),
+        "INSERT INTO orders (total) VALUES ($1)", 100)
+    require.NoError(t, err)
+
+    golden.AssertGolden(t, "TestCreateOrder")
+}
+```
+
+On the first run, the test writes `testdata/golden/TestCreateOrder.json` and logs that a baseline was created. On subsequent runs, it compares the recorded transcript against that file and fails with a unified diff on any mismatch.
+
+### What the Transcript Captures
+
+Every event pgxkit observes ends up in the transcript, in order:
+
+- `BEGIN`, `COMMIT`, `ROLLBACK` for transactions started via `BeginTx`.
+- `QUERY` events for every `Query`, `QueryRow`, and `Exec` call — including DDL (`CREATE TABLE`, `ALTER`, etc.) and `SET` statements. There is no SQL-prefix filter.
+- For `Query` and `QueryRow`, materialized result rows as `column → value` maps.
+- For `Exec`, the `rows_affected` integer from the command tag.
+
+Caller iteration of `pgx.Rows` still works normally — pgxkit reads the rows once for the transcript, then replays them through a wrapper.
+
+### Refreshing the Baseline
+
+When you intentionally change behavior (a new column in a returning clause, an extra normalization step, a deliberate query reorder), regenerate the baseline:
+
+```bash
+go test -overwrite-golden -run TestCreateOrder
+```
+
+The flag is package-scoped on pgxkit, so any test binary that links pgxkit accepts it.
+
+### Normalization Defaults
+
+To keep transcripts stable across runs, volatile values are replaced with placeholders before the transcript is written or compared:
+
+- `time.Time` values → `"<TIMESTAMP>"`.
+- UUIDs (`uuid.UUID`, `[16]byte`, or canonical UUID strings) → `"<UUID:1>"`, `"<UUID:2>"`, ... assigned in first-seen order, so the same UUID gets the same placeholder wherever it appears.
+- Integer columns whose name is `id` or ends in `_id` → `"<ID:1>"`, `"<ID:2>"`, ... also first-seen by numeric value (so `id=7` and `user_id=7` collapse to the same placeholder).
+
+Args have no column hint, so integer normalization does not trigger there; timestamps and UUIDs do.
+
+### Custom Normalization
+
+Add domain-specific normalizers via `WithGoldenNormalizer`. Custom normalizers run **before** defaults, so you can override `time.Time` handling, redact sensitive fields, or canonicalize ordering of map-shaped values:
+
+```go
+golden := testDB.EnableGolden("TestCreateOrder",
+    pgxkit.WithGoldenNormalizer(func(v any) (any, bool) {
+        if s, ok := v.(string); ok && strings.HasPrefix(s, "ord_") {
+            return "<ORDER>", true
+        }
+        return nil, false
+    }),
+)
+```
+
+Return `(replacement, true)` to take over normalization for the value, or `(nil, false)` to fall through to the next custom normalizer or to the defaults.
+
+### Limitations
+
+- `golden`-recorded `pgx.Rows` materializes data once; `RawValues()` returns nil and the wrapper is not bound to a live connection (`Conn()` returns nil). `Scan` covers the common destination kinds (strings, numerics, bools, time.Time, byte slices, `*any`, types implementing `sql.Scanner`, plus a reflect-based fallback for assignable types).
+- Concurrent fan-out within a single scenario is out of scope — captured order would be non-deterministic.
+
 ## Testing Patterns
 
 ### Table-Driven Tests
@@ -1097,6 +1177,7 @@ func TestUserService_GetActiveUsers_Bad(t *testing.T) {
 - [ ] Unit tests for business logic
 - [ ] Integration tests for database operations
 - [ ] Plan-regression tests for query plan shape
+- [ ] Golden transcript tests for behavioral stability
 - [ ] Error condition testing
 - [ ] Concurrent operation testing
 - [ ] Benchmark tests for critical paths

--- a/docs/Testing-Guide.md
+++ b/docs/Testing-Guide.md
@@ -574,7 +574,6 @@ This complements [Plan-Regression Testing](#plan-regression-testing): plan-regre
 ```go
 func TestCreateOrder(t *testing.T) {
     testDB := pgxkit.RequireDB(t)
-    defer pgxkit.CleanupGolden("TestCreateOrder")
 
     golden := testDB.EnableGolden("TestCreateOrder")
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.2
+	github.com/pmezard/go-difflib v1.0.0
 )
 
 require (

--- a/golden.go
+++ b/golden.go
@@ -1,0 +1,404 @@
+package pgxkit
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+// goldenT captures the subset of *testing.T that assertGolden needs. Splitting
+// it out lets us drive assertGolden from unit tests with a fake.
+type goldenT interface {
+	Helper()
+	Errorf(format string, args ...any)
+	Logf(format string, args ...any)
+}
+
+// overwriteGolden, when set, regenerates testdata/golden baselines instead of
+// asserting them. The flag is registered at package scope so it can be passed
+// as `go test -overwrite-golden` from any test invocation that links pgxkit.
+var overwriteGolden = flag.Bool("overwrite-golden", false, "regenerate testdata/golden baselines instead of asserting")
+
+// transcriptEvent is one entry in a recorded transcript. omitempty keeps each
+// event lean — non-applicable fields don't appear in the serialized JSON.
+type transcriptEvent struct {
+	Step         int              `json:"step"`
+	Event        string           `json:"event"`
+	SQL          string           `json:"sql,omitempty"`
+	Args         []any            `json:"args,omitempty"`
+	Rows         []map[string]any `json:"rows,omitempty"`
+	RowsAffected *int64           `json:"rows_affected,omitempty"`
+}
+
+// Event names used in the transcript.
+const (
+	transcriptEventBegin    = "BEGIN"
+	transcriptEventCommit   = "COMMIT"
+	transcriptEventRollback = "ROLLBACK"
+	transcriptEventQuery    = "QUERY"
+)
+
+// transcriptRecorder collects a sequential transcript of database events for a
+// single golden test scenario. It is shared between a *DB returned by
+// EnableGolden and any *Tx that DB starts so a multi-statement transaction
+// records as one ordered stream.
+type transcriptRecorder struct {
+	mu         sync.Mutex
+	testName   string
+	events     []transcriptEvent
+	step       int
+	normalizer *normalizer
+}
+
+// GoldenOption configures a transcript recorder created by EnableGolden.
+type GoldenOption func(*transcriptRecorder)
+
+// WithGoldenNormalizer registers a custom normalizer that runs before pgxkit's
+// defaults. Return ok=true to take over normalization for the value; return
+// ok=false to fall through to the next custom normalizer or the defaults.
+func WithGoldenNormalizer(fn func(any) (any, bool)) GoldenOption {
+	return func(r *transcriptRecorder) {
+		r.normalizer.custom = append(r.normalizer.custom, fn)
+	}
+}
+
+func newTranscriptRecorder(testName string, opts ...GoldenOption) *transcriptRecorder {
+	r := &transcriptRecorder{
+		testName:   testName,
+		normalizer: newNormalizer(),
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// nextStep returns the next 1-based step number. Caller must hold r.mu.
+func (r *transcriptRecorder) nextStep() int {
+	r.step++
+	return r.step
+}
+
+func (r *transcriptRecorder) recordBegin() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, transcriptEvent{
+		Step:  r.nextStep(),
+		Event: transcriptEventBegin,
+	})
+}
+
+func (r *transcriptRecorder) recordCommit(_ error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, transcriptEvent{
+		Step:  r.nextStep(),
+		Event: transcriptEventCommit,
+	})
+}
+
+func (r *transcriptRecorder) recordRollback(_ error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, transcriptEvent{
+		Step:  r.nextStep(),
+		Event: transcriptEventRollback,
+	})
+}
+
+// recordQuery captures a SELECT-shaped result with materialized rows.
+// rows are already-normalized column→value maps in field order.
+func (r *transcriptRecorder) recordQuery(sql string, args []any, rows []map[string]any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	normalizedArgs := r.normalizeArgs(args)
+	if rows == nil {
+		rows = []map[string]any{}
+	}
+	r.events = append(r.events, transcriptEvent{
+		Step:  r.nextStep(),
+		Event: transcriptEventQuery,
+		SQL:   sql,
+		Args:  normalizedArgs,
+		Rows:  rows,
+	})
+}
+
+// recordExec captures a command-tag result (no rows; rows_affected only).
+func (r *transcriptRecorder) recordExec(sql string, args []any, rowsAffected int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	normalizedArgs := r.normalizeArgs(args)
+	ra := rowsAffected
+	r.events = append(r.events, transcriptEvent{
+		Step:         r.nextStep(),
+		Event:        transcriptEventQuery,
+		SQL:          sql,
+		Args:         normalizedArgs,
+		RowsAffected: &ra,
+	})
+}
+
+// normalizeArgs normalizes positional query args. Caller must hold r.mu.
+// Args have no column hint, so int normalization (which keys off column name)
+// does not trigger here — only timestamps and UUIDs are replaced.
+func (r *transcriptRecorder) normalizeArgs(args []any) []any {
+	if len(args) == 0 {
+		return nil
+	}
+	out := make([]any, len(args))
+	for i, a := range args {
+		out[i] = r.normalizer.normalize(a, "")
+	}
+	return out
+}
+
+// normalizeRow normalizes one decoded row by column name. Caller must hold r.mu.
+func (r *transcriptRecorder) normalizeRow(columnNames []string, values []any) map[string]any {
+	out := make(map[string]any, len(columnNames))
+	for i, name := range columnNames {
+		var v any
+		if i < len(values) {
+			v = values[i]
+		}
+		out[name] = r.normalizer.normalize(v, name)
+	}
+	return out
+}
+
+// normalizer replaces volatile values (timestamps, UUIDs, sequence IDs) with
+// stable placeholders so transcripts compare cleanly across runs. UUIDs and
+// IDs use first-seen ordering within the scenario so the same value in two
+// places gets the same placeholder.
+type normalizer struct {
+	uuids  map[string]int
+	ids    map[string]int
+	custom []func(any) (any, bool)
+}
+
+func newNormalizer() *normalizer {
+	return &normalizer{
+		uuids: make(map[string]int),
+		ids:   make(map[string]int),
+	}
+}
+
+var uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// normalize returns a placeholder for volatile values. columnHint is the
+// column name (for row values) or "" (for query args). Custom normalizers run
+// before defaults so users can override.
+func (n *normalizer) normalize(value any, columnHint string) any {
+	for _, fn := range n.custom {
+		if replaced, ok := fn(value); ok {
+			return replaced
+		}
+	}
+
+	if value == nil {
+		return nil
+	}
+
+	switch v := value.(type) {
+	case time.Time:
+		return "<TIMESTAMP>"
+	case *time.Time:
+		if v == nil {
+			return nil
+		}
+		return "<TIMESTAMP>"
+	case uuid.UUID:
+		return n.placeholderForUUID(v.String())
+	case [16]byte:
+		u := uuid.UUID(v)
+		return n.placeholderForUUID(u.String())
+	case string:
+		if uuidRegex.MatchString(v) {
+			return n.placeholderForUUID(strings.ToLower(v))
+		}
+	}
+
+	if isIDColumn(columnHint) {
+		if key, ok := intKey(value); ok {
+			return n.placeholderForID(key)
+		}
+	}
+
+	return value
+}
+
+func (n *normalizer) placeholderForUUID(canonical string) string {
+	canonical = strings.ToLower(canonical)
+	if idx, ok := n.uuids[canonical]; ok {
+		return fmt.Sprintf("<UUID:%d>", idx)
+	}
+	idx := len(n.uuids) + 1
+	n.uuids[canonical] = idx
+	return fmt.Sprintf("<UUID:%d>", idx)
+}
+
+func (n *normalizer) placeholderForID(key string) string {
+	if idx, ok := n.ids[key]; ok {
+		return fmt.Sprintf("<ID:%d>", idx)
+	}
+	idx := len(n.ids) + 1
+	n.ids[key] = idx
+	return fmt.Sprintf("<ID:%d>", idx)
+}
+
+// isIDColumn reports whether a column name indicates a sequence-style ID
+// suitable for normalization. Hint is empty for positional args.
+func isIDColumn(hint string) bool {
+	if hint == "" {
+		return false
+	}
+	if hint == "id" {
+		return true
+	}
+	return strings.HasSuffix(hint, "_id")
+}
+
+// intKey returns a stable string key for any signed/unsigned integer value
+// so that int and int64 with the same numeric value collapse to one entry.
+func intKey(value any) (string, bool) {
+	switch v := value.(type) {
+	case int:
+		return strconv.FormatInt(int64(v), 10), true
+	case int8:
+		return strconv.FormatInt(int64(v), 10), true
+	case int16:
+		return strconv.FormatInt(int64(v), 10), true
+	case int32:
+		return strconv.FormatInt(int64(v), 10), true
+	case int64:
+		return strconv.FormatInt(v, 10), true
+	case uint:
+		return strconv.FormatUint(uint64(v), 10), true
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10), true
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10), true
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10), true
+	case uint64:
+		return strconv.FormatUint(v, 10), true
+	}
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(rv.Int(), 10), true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return strconv.FormatUint(rv.Uint(), 10), true
+	}
+	return "", false
+}
+
+// goldenPath returns the on-disk path for a named transcript baseline.
+func goldenPath(name string) string {
+	return filepath.Join("testdata", "golden", name+".json")
+}
+
+// marshalEvents renders the recorder's events as canonical pretty-printed JSON
+// with a trailing newline. Empty event slices serialize as `[]`, not `null`.
+func marshalEvents(events []transcriptEvent) ([]byte, error) {
+	if events == nil {
+		events = []transcriptEvent{}
+	}
+	data, err := json.MarshalIndent(events, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	data = append(data, '\n')
+	return data, nil
+}
+
+// writeGolden writes pretty-printed transcript bytes, creating the directory.
+func writeGolden(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("failed to create golden directory: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write golden file %s: %w", path, err)
+	}
+	return nil
+}
+
+// compareGolden compares baseline to current bytes. If they match, ok is true
+// and diff is empty. Otherwise diff is a unified diff string. Extracted as a
+// pure function so it can be unit tested without a *testing.T.
+func compareGolden(path string, baseline, current []byte) (string, bool) {
+	if bytes.Equal(baseline, current) {
+		return "", true
+	}
+	udiff := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(baseline)),
+		B:        difflib.SplitLines(string(current)),
+		FromFile: path + " (baseline)",
+		ToFile:   path + " (current)",
+		Context:  3,
+	}
+	out, err := difflib.GetUnifiedDiffString(udiff)
+	if err != nil {
+		return fmt.Sprintf("(failed to render diff: %v)", err), false
+	}
+	return out, false
+}
+
+// assertGolden marshals the recorder's transcript and compares it against the
+// baseline file, writing the baseline on first run or when -overwrite-golden
+// is set.
+func assertGolden(t goldenT, recorder *transcriptRecorder) {
+	t.Helper()
+
+	recorder.mu.Lock()
+	events := append([]transcriptEvent(nil), recorder.events...)
+	name := recorder.testName
+	recorder.mu.Unlock()
+
+	current, err := marshalEvents(events)
+	if err != nil {
+		t.Errorf("failed to marshal transcript: %v", err)
+		return
+	}
+
+	path := goldenPath(name)
+	_, statErr := os.Stat(path)
+	missing := os.IsNotExist(statErr)
+
+	if missing || (overwriteGolden != nil && *overwriteGolden) {
+		if err := writeGolden(path, current); err != nil {
+			t.Errorf("%v", err)
+			return
+		}
+		if missing {
+			t.Logf("created golden baseline: %s", path)
+		} else {
+			t.Logf("regenerated golden baseline: %s", path)
+		}
+		return
+	}
+
+	baseline, err := os.ReadFile(path)
+	if err != nil {
+		t.Errorf("failed to read golden file %s: %v", path, err)
+		return
+	}
+
+	diff, ok := compareGolden(path, baseline, current)
+	if ok {
+		return
+	}
+	t.Errorf("golden transcript mismatch for %s\n%s", path, diff)
+}

--- a/golden_rows.go
+++ b/golden_rows.go
@@ -1,0 +1,381 @@
+package pgxkit
+
+import (
+	"database/sql"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// captureRowsForGolden materializes a live pgx.Rows into a replayRows the
+// caller can iterate, while also recording a normalized snapshot of the rows
+// on the recorder. The original pgx.Rows is consumed and closed.
+func captureRowsForGolden(rows pgx.Rows, recorder *transcriptRecorder, sql string, args []any) (*replayRows, error) {
+	defer rows.Close()
+
+	fields := append([]pgconn.FieldDescription(nil), rows.FieldDescriptions()...)
+	columnNames := make([]string, len(fields))
+	for i, f := range fields {
+		columnNames[i] = f.Name
+	}
+
+	var captured [][]any
+	var normalized []map[string]any
+	for rows.Next() {
+		values, err := rows.Values()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read row values for golden capture: %w", err)
+		}
+		copyValues := make([]any, len(values))
+		copy(copyValues, values)
+		captured = append(captured, copyValues)
+		normalized = append(normalized, recorder.normalizeRow(columnNames, copyValues))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	recorder.recordQuery(sql, args, normalized)
+	return newReplayRows(fields, captured, nil), nil
+}
+
+// replayRows materializes a query result so the recorder can capture it while
+// still letting the caller iterate normally. Rows are decoded once via pgx
+// (rows.Values()) and then replayed through the pgx.Rows interface.
+//
+// Documented limitations:
+//   - RawValues returns nil; the underlying pgx wire bytes are not retained.
+//   - Conn returns nil; replayRows is not bound to a live connection.
+type replayRows struct {
+	fields []pgconn.FieldDescription
+	rows   [][]any
+	cursor int
+	closed bool
+	err    error
+}
+
+func newReplayRows(fields []pgconn.FieldDescription, rows [][]any, err error) *replayRows {
+	return &replayRows{
+		fields: fields,
+		rows:   rows,
+		cursor: -1,
+		err:    err,
+	}
+}
+
+func (r *replayRows) Next() bool {
+	if r.closed || r.err != nil {
+		return false
+	}
+	r.cursor++
+	return r.cursor < len(r.rows)
+}
+
+func (r *replayRows) Values() ([]any, error) {
+	if r.cursor < 0 || r.cursor >= len(r.rows) {
+		return nil, fmt.Errorf("replayRows: Values called outside iteration")
+	}
+	row := r.rows[r.cursor]
+	out := make([]any, len(row))
+	copy(out, row)
+	return out, nil
+}
+
+func (r *replayRows) Scan(dest ...any) error {
+	if r.cursor < 0 || r.cursor >= len(r.rows) {
+		return fmt.Errorf("replayRows: Scan called outside iteration")
+	}
+	row := r.rows[r.cursor]
+	if len(dest) != len(row) {
+		return fmt.Errorf("replayRows: Scan got %d destinations, row has %d columns", len(dest), len(row))
+	}
+	for i := range dest {
+		colName := ""
+		if i < len(r.fields) {
+			colName = r.fields[i].Name
+		}
+		if err := assignReplay(dest[i], row[i], colName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *replayRows) FieldDescriptions() []pgconn.FieldDescription {
+	return r.fields
+}
+
+func (r *replayRows) Err() error {
+	return r.err
+}
+
+func (r *replayRows) Close() {
+	r.closed = true
+}
+
+func (r *replayRows) CommandTag() pgconn.CommandTag {
+	return pgconn.CommandTag{}
+}
+
+// Conn returns nil — replayRows is not bound to a live connection.
+func (r *replayRows) Conn() *pgx.Conn {
+	return nil
+}
+
+// RawValues returns nil — the underlying wire bytes are not retained after
+// the original rows.Values() decode.
+func (r *replayRows) RawValues() [][]byte {
+	return nil
+}
+
+// replayRow wraps the first row of a captured result for QueryRow callers.
+// On empty results, Scan returns pgx.ErrNoRows.
+type replayRow struct {
+	rows *replayRows
+}
+
+func (r *replayRow) Scan(dest ...any) error {
+	if r.rows.err != nil {
+		return r.rows.err
+	}
+	if !r.rows.Next() {
+		return pgx.ErrNoRows
+	}
+	defer r.rows.Close()
+	return r.rows.Scan(dest...)
+}
+
+// assignReplay assigns src to dst, handling the common pgx-style destination
+// kinds plus a reflect-based fallback for assignable types.
+func assignReplay(dst, src any, colName string) error {
+	if dst == nil {
+		return fmt.Errorf("replayRows: nil destination for column %q", colName)
+	}
+
+	if scanner, ok := dst.(sql.Scanner); ok {
+		return scanner.Scan(src)
+	}
+
+	switch d := dst.(type) {
+	case *any:
+		*d = src
+		return nil
+	case *string:
+		s, err := toString(src)
+		if err != nil {
+			return scanErr(colName, src, dst, err)
+		}
+		*d = s
+		return nil
+	case *[]byte:
+		b, ok := src.([]byte)
+		if !ok {
+			return scanErr(colName, src, dst, nil)
+		}
+		*d = b
+		return nil
+	case *bool:
+		b, ok := src.(bool)
+		if !ok {
+			return scanErr(colName, src, dst, nil)
+		}
+		*d = b
+		return nil
+	case *time.Time:
+		t, ok := src.(time.Time)
+		if !ok {
+			return scanErr(colName, src, dst, nil)
+		}
+		*d = t
+		return nil
+	case *float32:
+		f, err := toFloat64(src)
+		if err != nil {
+			return scanErr(colName, src, dst, err)
+		}
+		*d = float32(f)
+		return nil
+	case *float64:
+		f, err := toFloat64(src)
+		if err != nil {
+			return scanErr(colName, src, dst, err)
+		}
+		*d = f
+		return nil
+	case *int:
+		n, err := toInt64(src)
+		if err != nil {
+			return scanErr(colName, src, dst, err)
+		}
+		*d = int(n)
+		return nil
+	case *int8:
+		n, err := toInt64(src)
+		if err != nil {
+			return scanErr(colName, src, dst, err)
+		}
+		*d = int8(n)
+		return nil
+	case *int16:
+		n, err := toInt64(src)
+		if err != nil {
+			return scanErr(colName, src, dst, err)
+		}
+		*d = int16(n)
+		return nil
+	case *int32:
+		n, err := toInt64(src)
+		if err != nil {
+			return scanErr(colName, src, dst, err)
+		}
+		*d = int32(n)
+		return nil
+	case *int64:
+		n, err := toInt64(src)
+		if err != nil {
+			return scanErr(colName, src, dst, err)
+		}
+		*d = n
+		return nil
+	case *uint:
+		n, err := toUint64(src)
+		if err != nil {
+			return scanErr(colName, src, dst, err)
+		}
+		*d = uint(n)
+		return nil
+	case *uint8:
+		n, err := toUint64(src)
+		if err != nil {
+			return scanErr(colName, src, dst, err)
+		}
+		*d = uint8(n)
+		return nil
+	case *uint16:
+		n, err := toUint64(src)
+		if err != nil {
+			return scanErr(colName, src, dst, err)
+		}
+		*d = uint16(n)
+		return nil
+	case *uint32:
+		n, err := toUint64(src)
+		if err != nil {
+			return scanErr(colName, src, dst, err)
+		}
+		*d = uint32(n)
+		return nil
+	case *uint64:
+		n, err := toUint64(src)
+		if err != nil {
+			return scanErr(colName, src, dst, err)
+		}
+		*d = n
+		return nil
+	}
+
+	dv := reflect.ValueOf(dst)
+	if dv.Kind() != reflect.Ptr || dv.IsNil() {
+		return fmt.Errorf("replayRows: destination for column %q is not a non-nil pointer", colName)
+	}
+	target := dv.Elem()
+	if src == nil {
+		target.Set(reflect.Zero(target.Type()))
+		return nil
+	}
+	sv := reflect.ValueOf(src)
+	if sv.Type().AssignableTo(target.Type()) {
+		target.Set(sv)
+		return nil
+	}
+	if sv.Type().ConvertibleTo(target.Type()) {
+		target.Set(sv.Convert(target.Type()))
+		return nil
+	}
+	return fmt.Errorf("replayRows: cannot scan column %q (%T) into %T", colName, src, dst)
+}
+
+func scanErr(colName string, src, dst any, cause error) error {
+	if cause != nil {
+		return fmt.Errorf("replayRows: cannot scan column %q (%T) into %T: %w", colName, src, dst, cause)
+	}
+	return fmt.Errorf("replayRows: cannot scan column %q (%T) into %T", colName, src, dst)
+}
+
+func toInt64(src any) (int64, error) {
+	switch v := src.(type) {
+	case int:
+		return int64(v), nil
+	case int8:
+		return int64(v), nil
+	case int16:
+		return int64(v), nil
+	case int32:
+		return int64(v), nil
+	case int64:
+		return v, nil
+	case uint:
+		return int64(v), nil
+	case uint8:
+		return int64(v), nil
+	case uint16:
+		return int64(v), nil
+	case uint32:
+		return int64(v), nil
+	case uint64:
+		return int64(v), nil
+	}
+	return 0, fmt.Errorf("not an integer (%T)", src)
+}
+
+func toUint64(src any) (uint64, error) {
+	switch v := src.(type) {
+	case int:
+		return uint64(v), nil
+	case int8:
+		return uint64(v), nil
+	case int16:
+		return uint64(v), nil
+	case int32:
+		return uint64(v), nil
+	case int64:
+		return uint64(v), nil
+	case uint:
+		return uint64(v), nil
+	case uint8:
+		return uint64(v), nil
+	case uint16:
+		return uint64(v), nil
+	case uint32:
+		return uint64(v), nil
+	case uint64:
+		return v, nil
+	}
+	return 0, fmt.Errorf("not an integer (%T)", src)
+}
+
+func toFloat64(src any) (float64, error) {
+	switch v := src.(type) {
+	case float32:
+		return float64(v), nil
+	case float64:
+		return v, nil
+	}
+	if n, err := toInt64(src); err == nil {
+		return float64(n), nil
+	}
+	return 0, fmt.Errorf("not a float (%T)", src)
+}
+
+func toString(src any) (string, error) {
+	switch v := src.(type) {
+	case string:
+		return v, nil
+	case []byte:
+		return string(v), nil
+	}
+	return "", fmt.Errorf("not a string (%T)", src)
+}

--- a/golden_rows.go
+++ b/golden_rows.go
@@ -278,7 +278,7 @@ func assignReplay(dst, src any, colName string) error {
 	}
 
 	dv := reflect.ValueOf(dst)
-	if dv.Kind() != reflect.Ptr || dv.IsNil() {
+	if dv.Kind() != reflect.Pointer || dv.IsNil() {
 		return fmt.Errorf("replayRows: destination for column %q is not a non-nil pointer", colName)
 	}
 	target := dv.Elem()

--- a/golden_rows.go
+++ b/golden_rows.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	"reflect"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -148,132 +147,20 @@ func (r *replayRow) Scan(dest ...any) error {
 	return r.rows.Scan(dest...)
 }
 
-// assignReplay assigns src to dst, handling the common pgx-style destination
-// kinds plus a reflect-based fallback for assignable types.
+// assignReplay assigns src to dst for the test-only replay path. sql.Scanner
+// destinations get the raw decoded value; everything else goes through
+// reflect-based assign-or-convert. Numeric width/sign conversions follow Go's
+// normal conversion rules (silent truncation/overflow), same as a hand-rolled
+// type switch.
 func assignReplay(dst, src any, colName string) error {
 	if dst == nil {
 		return fmt.Errorf("replayRows: nil destination for column %q", colName)
 	}
-
 	if scanner, ok := dst.(sql.Scanner); ok {
 		return scanner.Scan(src)
 	}
-
-	switch d := dst.(type) {
-	case *any:
+	if d, ok := dst.(*any); ok {
 		*d = src
-		return nil
-	case *string:
-		s, err := toString(src)
-		if err != nil {
-			return scanErr(colName, src, dst, err)
-		}
-		*d = s
-		return nil
-	case *[]byte:
-		b, ok := src.([]byte)
-		if !ok {
-			return scanErr(colName, src, dst, nil)
-		}
-		*d = b
-		return nil
-	case *bool:
-		b, ok := src.(bool)
-		if !ok {
-			return scanErr(colName, src, dst, nil)
-		}
-		*d = b
-		return nil
-	case *time.Time:
-		t, ok := src.(time.Time)
-		if !ok {
-			return scanErr(colName, src, dst, nil)
-		}
-		*d = t
-		return nil
-	case *float32:
-		f, err := toFloat64(src)
-		if err != nil {
-			return scanErr(colName, src, dst, err)
-		}
-		*d = float32(f)
-		return nil
-	case *float64:
-		f, err := toFloat64(src)
-		if err != nil {
-			return scanErr(colName, src, dst, err)
-		}
-		*d = f
-		return nil
-	case *int:
-		n, err := toInt64(src)
-		if err != nil {
-			return scanErr(colName, src, dst, err)
-		}
-		*d = int(n)
-		return nil
-	case *int8:
-		n, err := toInt64(src)
-		if err != nil {
-			return scanErr(colName, src, dst, err)
-		}
-		*d = int8(n)
-		return nil
-	case *int16:
-		n, err := toInt64(src)
-		if err != nil {
-			return scanErr(colName, src, dst, err)
-		}
-		*d = int16(n)
-		return nil
-	case *int32:
-		n, err := toInt64(src)
-		if err != nil {
-			return scanErr(colName, src, dst, err)
-		}
-		*d = int32(n)
-		return nil
-	case *int64:
-		n, err := toInt64(src)
-		if err != nil {
-			return scanErr(colName, src, dst, err)
-		}
-		*d = n
-		return nil
-	case *uint:
-		n, err := toUint64(src)
-		if err != nil {
-			return scanErr(colName, src, dst, err)
-		}
-		*d = uint(n)
-		return nil
-	case *uint8:
-		n, err := toUint64(src)
-		if err != nil {
-			return scanErr(colName, src, dst, err)
-		}
-		*d = uint8(n)
-		return nil
-	case *uint16:
-		n, err := toUint64(src)
-		if err != nil {
-			return scanErr(colName, src, dst, err)
-		}
-		*d = uint16(n)
-		return nil
-	case *uint32:
-		n, err := toUint64(src)
-		if err != nil {
-			return scanErr(colName, src, dst, err)
-		}
-		*d = uint32(n)
-		return nil
-	case *uint64:
-		n, err := toUint64(src)
-		if err != nil {
-			return scanErr(colName, src, dst, err)
-		}
-		*d = n
 		return nil
 	}
 
@@ -296,86 +183,4 @@ func assignReplay(dst, src any, colName string) error {
 		return nil
 	}
 	return fmt.Errorf("replayRows: cannot scan column %q (%T) into %T", colName, src, dst)
-}
-
-func scanErr(colName string, src, dst any, cause error) error {
-	if cause != nil {
-		return fmt.Errorf("replayRows: cannot scan column %q (%T) into %T: %w", colName, src, dst, cause)
-	}
-	return fmt.Errorf("replayRows: cannot scan column %q (%T) into %T", colName, src, dst)
-}
-
-func toInt64(src any) (int64, error) {
-	switch v := src.(type) {
-	case int:
-		return int64(v), nil
-	case int8:
-		return int64(v), nil
-	case int16:
-		return int64(v), nil
-	case int32:
-		return int64(v), nil
-	case int64:
-		return v, nil
-	case uint:
-		return int64(v), nil
-	case uint8:
-		return int64(v), nil
-	case uint16:
-		return int64(v), nil
-	case uint32:
-		return int64(v), nil
-	case uint64:
-		return int64(v), nil
-	}
-	return 0, fmt.Errorf("not an integer (%T)", src)
-}
-
-func toUint64(src any) (uint64, error) {
-	switch v := src.(type) {
-	case int:
-		return uint64(v), nil
-	case int8:
-		return uint64(v), nil
-	case int16:
-		return uint64(v), nil
-	case int32:
-		return uint64(v), nil
-	case int64:
-		return uint64(v), nil
-	case uint:
-		return uint64(v), nil
-	case uint8:
-		return uint64(v), nil
-	case uint16:
-		return uint64(v), nil
-	case uint32:
-		return uint64(v), nil
-	case uint64:
-		return v, nil
-	}
-	return 0, fmt.Errorf("not an integer (%T)", src)
-}
-
-func toFloat64(src any) (float64, error) {
-	switch v := src.(type) {
-	case float32:
-		return float64(v), nil
-	case float64:
-		return v, nil
-	}
-	if n, err := toInt64(src); err == nil {
-		return float64(n), nil
-	}
-	return 0, fmt.Errorf("not a float (%T)", src)
-}
-
-func toString(src any) (string, error) {
-	switch v := src.(type) {
-	case string:
-		return v, nil
-	case []byte:
-		return string(v), nil
-	}
-	return "", fmt.Errorf("not a string (%T)", src)
 }

--- a/golden_test.go
+++ b/golden_test.go
@@ -58,8 +58,8 @@ func TestGolden_FirstRunCreatesBaseline(t *testing.T) {
 	}
 	withGoldenSchema(t, testDB, "golden_first_run")
 	const name = "TestGolden_FirstRunCreatesBaseline"
-	defer CleanupGolden(name)
-	_ = CleanupGolden(name)
+	defer cleanupGolden(name)
+	_ = cleanupGolden(name)
 
 	ctx := context.Background()
 	g := testDB.EnableGolden(name)
@@ -85,8 +85,8 @@ func TestGolden_SecondRunNoDiff(t *testing.T) {
 	}
 	withGoldenSchema(t, testDB, "golden_second_run")
 	const name = "TestGolden_SecondRunNoDiff"
-	defer CleanupGolden(name)
-	_ = CleanupGolden(name)
+	defer cleanupGolden(name)
+	_ = cleanupGolden(name)
 
 	ctx := context.Background()
 	for run := 0; run < 2; run++ {
@@ -114,8 +114,8 @@ func TestGolden_FailsOnExtraQuery(t *testing.T) {
 	}
 	withGoldenSchema(t, testDB, "golden_extra")
 	const name = "TestGolden_FailsOnExtraQuery"
-	defer CleanupGolden(name)
-	_ = CleanupGolden(name)
+	defer cleanupGolden(name)
+	_ = cleanupGolden(name)
 
 	ctx := context.Background()
 
@@ -153,8 +153,8 @@ func TestGolden_FailsOnDifferentArgs(t *testing.T) {
 	}
 	withGoldenSchema(t, testDB, "golden_diff_args")
 	const name = "TestGolden_FailsOnDifferentArgs"
-	defer CleanupGolden(name)
-	_ = CleanupGolden(name)
+	defer cleanupGolden(name)
+	_ = cleanupGolden(name)
 
 	ctx := context.Background()
 
@@ -181,8 +181,8 @@ func TestGolden_FailsOnDifferentRow(t *testing.T) {
 	}
 	withGoldenSchema(t, testDB, "golden_diff_row")
 	const name = "TestGolden_FailsOnDifferentRow"
-	defer CleanupGolden(name)
-	_ = CleanupGolden(name)
+	defer cleanupGolden(name)
+	_ = cleanupGolden(name)
 
 	ctx := context.Background()
 
@@ -234,8 +234,8 @@ func TestGolden_FailsOnMissingExec(t *testing.T) {
 	}
 	withGoldenSchema(t, testDB, "golden_missing")
 	const name = "TestGolden_FailsOnMissingExec"
-	defer CleanupGolden(name)
-	_ = CleanupGolden(name)
+	defer cleanupGolden(name)
+	_ = cleanupGolden(name)
 
 	ctx := context.Background()
 
@@ -263,8 +263,8 @@ func TestGolden_FailsCommitToRollback(t *testing.T) {
 	}
 	withGoldenSchema(t, testDB, "golden_commit_rollback")
 	const name = "TestGolden_FailsCommitToRollback"
-	defer CleanupGolden(name)
-	_ = CleanupGolden(name)
+	defer cleanupGolden(name)
+	_ = cleanupGolden(name)
 
 	ctx := context.Background()
 
@@ -306,8 +306,8 @@ func TestGolden_TransactionPreservesOrder(t *testing.T) {
 	}
 	withGoldenSchema(t, testDB, "golden_tx_order")
 	const name = "TestGolden_TransactionPreservesOrder"
-	defer CleanupGolden(name)
-	_ = CleanupGolden(name)
+	defer cleanupGolden(name)
+	_ = cleanupGolden(name)
 
 	ctx := context.Background()
 	g := testDB.EnableGolden(name)
@@ -434,8 +434,8 @@ func TestGolden_DDLAndSetRecordedAsQuery(t *testing.T) {
 	}
 	const name = "TestGolden_DDLAndSet"
 	const table = "golden_ddl_set"
-	defer CleanupGolden(name)
-	_ = CleanupGolden(name)
+	defer cleanupGolden(name)
+	_ = cleanupGolden(name)
 	t.Cleanup(func() {
 		_, _ = testDB.Exec(context.Background(), "DROP TABLE IF EXISTS "+table)
 	})
@@ -476,8 +476,8 @@ func TestGolden_OverwriteFlagRegeneratesBaseline(t *testing.T) {
 	}
 	withGoldenSchema(t, testDB, "golden_overwrite")
 	const name = "TestGolden_OverwriteFlag"
-	defer CleanupGolden(name)
-	_ = CleanupGolden(name)
+	defer cleanupGolden(name)
+	_ = cleanupGolden(name)
 
 	ctx := context.Background()
 
@@ -537,7 +537,7 @@ func TestGolden_CleanupRemovesFile(t *testing.T) {
 	}
 	withGoldenSchema(t, testDB, "golden_cleanup")
 	const name = "TestGolden_CleanupRemovesFile"
-	_ = CleanupGolden(name)
+	_ = cleanupGolden(name)
 
 	ctx := context.Background()
 	g := testDB.EnableGolden(name)
@@ -546,14 +546,14 @@ func TestGolden_CleanupRemovesFile(t *testing.T) {
 	if !goldenFileExists(name) {
 		t.Fatalf("expected golden file to exist before cleanup")
 	}
-	if err := CleanupGolden(name); err != nil {
+	if err := cleanupGolden(name); err != nil {
 		t.Fatalf("cleanup: %v", err)
 	}
 	if goldenFileExists(name) {
-		t.Errorf("expected golden file to be removed after CleanupGolden")
+		t.Errorf("expected golden file to be removed after cleanupGolden")
 	}
-	if err := CleanupGolden(name); err != nil {
-		t.Errorf("CleanupGolden should be idempotent: %v", err)
+	if err := cleanupGolden(name); err != nil {
+		t.Errorf("cleanupGolden should be idempotent: %v", err)
 	}
 }
 
@@ -564,8 +564,8 @@ func TestGolden_QueryRowReturnsErrNoRowsOnEmpty(t *testing.T) {
 	}
 	withGoldenSchema(t, testDB, "golden_no_rows")
 	const name = "TestGolden_QueryRowEmpty"
-	defer CleanupGolden(name)
-	_ = CleanupGolden(name)
+	defer cleanupGolden(name)
+	_ = cleanupGolden(name)
 
 	ctx := context.Background()
 	g := testDB.EnableGolden(name)

--- a/golden_test.go
+++ b/golden_test.go
@@ -1,0 +1,601 @@
+package pgxkit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// withGoldenSchema creates a regular (non-temp) table for golden testing and
+// returns its name. It registers a Cleanup to drop the table. Regular tables
+// are required because the *DB returned by EnableGolden shares the underlying
+// pool and DML may run on a different connection than the CREATE.
+func withGoldenSchema(t *testing.T, testDB *TestDB, table string) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := testDB.Exec(ctx, "CREATE TABLE IF NOT EXISTS "+table+" ("+
+		"id SERIAL PRIMARY KEY, "+
+		"name TEXT NOT NULL, "+
+		"created_at TIMESTAMPTZ NOT NULL DEFAULT NOW())")
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testDB.Exec(context.Background(), "DROP TABLE IF EXISTS "+table)
+	})
+	_, err = testDB.Exec(ctx, "TRUNCATE "+table+" RESTART IDENTITY")
+	if err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+}
+
+func goldenFileExists(name string) bool {
+	_, err := os.Stat(goldenPath(name))
+	return err == nil
+}
+
+// readGoldenFile returns the raw bytes of the named golden file or fails.
+func readGoldenFile(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(goldenPath(name))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	return data
+}
+
+func TestGolden_FirstRunCreatesBaseline(t *testing.T) {
+	testDB := RequireDB(t)
+	if testDB == nil {
+		return
+	}
+	withGoldenSchema(t, testDB, "golden_first_run")
+	const name = "TestGolden_FirstRunCreatesBaseline"
+	defer CleanupGolden(name)
+	_ = CleanupGolden(name)
+
+	ctx := context.Background()
+	g := testDB.EnableGolden(name)
+
+	_, err := g.Exec(ctx, "INSERT INTO golden_first_run (name) VALUES ($1)", "alpha")
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	g.AssertGolden(t, name)
+	if t.Failed() {
+		return
+	}
+	if !goldenFileExists(name) {
+		t.Fatalf("expected golden file to be created at %s", goldenPath(name))
+	}
+}
+
+func TestGolden_SecondRunNoDiff(t *testing.T) {
+	testDB := RequireDB(t)
+	if testDB == nil {
+		return
+	}
+	withGoldenSchema(t, testDB, "golden_second_run")
+	const name = "TestGolden_SecondRunNoDiff"
+	defer CleanupGolden(name)
+	_ = CleanupGolden(name)
+
+	ctx := context.Background()
+	for run := 0; run < 2; run++ {
+		_, _ = testDB.Exec(ctx, "TRUNCATE golden_second_run RESTART IDENTITY")
+		g := testDB.EnableGolden(name)
+		_, err := g.Exec(ctx, "INSERT INTO golden_second_run (name) VALUES ($1)", "alpha")
+		if err != nil {
+			t.Fatalf("insert run %d: %v", run, err)
+		}
+		_, err = g.Exec(ctx, "INSERT INTO golden_second_run (name) VALUES ($1)", "beta")
+		if err != nil {
+			t.Fatalf("insert run %d: %v", run, err)
+		}
+		g.AssertGolden(t, name)
+		if t.Failed() {
+			t.Fatalf("run %d should not fail", run)
+		}
+	}
+}
+
+func TestGolden_FailsOnExtraQuery(t *testing.T) {
+	testDB := RequireDB(t)
+	if testDB == nil {
+		return
+	}
+	withGoldenSchema(t, testDB, "golden_extra")
+	const name = "TestGolden_FailsOnExtraQuery"
+	defer CleanupGolden(name)
+	_ = CleanupGolden(name)
+
+	ctx := context.Background()
+
+	g1 := testDB.EnableGolden(name)
+	if _, err := g1.Exec(ctx, "INSERT INTO golden_extra (name) VALUES ($1)", "a"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	g1.AssertGolden(t, name)
+	if t.Failed() {
+		t.Fatalf("baseline run should pass")
+	}
+
+	g2 := testDB.EnableGolden(name)
+	if _, err := g2.Exec(ctx, "INSERT INTO golden_extra (name) VALUES ($1)", "a"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, err := g2.Exec(ctx, "INSERT INTO golden_extra (name) VALUES ($1)", "b"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	mt := &capturingT{}
+	assertGolden(mt, g2.recorder)
+	if !mt.failed {
+		t.Errorf("expected mismatch failure for extra query")
+	}
+	if !strings.Contains(mt.errorMsg, "golden transcript mismatch") {
+		t.Errorf("expected diff message, got: %s", mt.errorMsg)
+	}
+}
+
+func TestGolden_FailsOnDifferentArgs(t *testing.T) {
+	testDB := RequireDB(t)
+	if testDB == nil {
+		return
+	}
+	withGoldenSchema(t, testDB, "golden_diff_args")
+	const name = "TestGolden_FailsOnDifferentArgs"
+	defer CleanupGolden(name)
+	_ = CleanupGolden(name)
+
+	ctx := context.Background()
+
+	g1 := testDB.EnableGolden(name)
+	_, _ = g1.Exec(ctx, "INSERT INTO golden_diff_args (name) VALUES ($1)", "alpha")
+	g1.AssertGolden(t, name)
+	if t.Failed() {
+		t.Fatalf("baseline run should pass")
+	}
+
+	g2 := testDB.EnableGolden(name)
+	_, _ = g2.Exec(ctx, "INSERT INTO golden_diff_args (name) VALUES ($1)", "DIFFERENT")
+	mt := &capturingT{}
+	assertGolden(mt, g2.recorder)
+	if !mt.failed {
+		t.Errorf("expected mismatch failure on differing args")
+	}
+}
+
+func TestGolden_FailsOnDifferentRow(t *testing.T) {
+	testDB := RequireDB(t)
+	if testDB == nil {
+		return
+	}
+	withGoldenSchema(t, testDB, "golden_diff_row")
+	const name = "TestGolden_FailsOnDifferentRow"
+	defer CleanupGolden(name)
+	_ = CleanupGolden(name)
+
+	ctx := context.Background()
+
+	if _, err := testDB.Exec(ctx, "INSERT INTO golden_diff_row (name) VALUES ('first')"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	g1 := testDB.EnableGolden(name)
+	rows, err := g1.Query(ctx, "SELECT name FROM golden_diff_row ORDER BY id")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	for rows.Next() {
+		var s string
+		_ = rows.Scan(&s)
+	}
+	rows.Close()
+	g1.AssertGolden(t, name)
+	if t.Failed() {
+		t.Fatalf("baseline run should pass")
+	}
+
+	if _, err := testDB.Exec(ctx, "UPDATE golden_diff_row SET name = 'changed' WHERE name = 'first'"); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	g2 := testDB.EnableGolden(name)
+	rows, err = g2.Query(ctx, "SELECT name FROM golden_diff_row ORDER BY id")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	for rows.Next() {
+		var s string
+		_ = rows.Scan(&s)
+	}
+	rows.Close()
+
+	mt := &capturingT{}
+	assertGolden(mt, g2.recorder)
+	if !mt.failed {
+		t.Errorf("expected mismatch on differing row")
+	}
+}
+
+func TestGolden_FailsOnMissingExec(t *testing.T) {
+	testDB := RequireDB(t)
+	if testDB == nil {
+		return
+	}
+	withGoldenSchema(t, testDB, "golden_missing")
+	const name = "TestGolden_FailsOnMissingExec"
+	defer CleanupGolden(name)
+	_ = CleanupGolden(name)
+
+	ctx := context.Background()
+
+	g1 := testDB.EnableGolden(name)
+	_, _ = g1.Exec(ctx, "INSERT INTO golden_missing (name) VALUES ($1)", "a")
+	_, _ = g1.Exec(ctx, "INSERT INTO golden_missing (name) VALUES ($1)", "b")
+	g1.AssertGolden(t, name)
+	if t.Failed() {
+		t.Fatalf("baseline run should pass")
+	}
+
+	g2 := testDB.EnableGolden(name)
+	_, _ = g2.Exec(ctx, "INSERT INTO golden_missing (name) VALUES ($1)", "a")
+	mt := &capturingT{}
+	assertGolden(mt, g2.recorder)
+	if !mt.failed {
+		t.Errorf("expected mismatch on missing exec")
+	}
+}
+
+func TestGolden_FailsCommitToRollback(t *testing.T) {
+	testDB := RequireDB(t)
+	if testDB == nil {
+		return
+	}
+	withGoldenSchema(t, testDB, "golden_commit_rollback")
+	const name = "TestGolden_FailsCommitToRollback"
+	defer CleanupGolden(name)
+	_ = CleanupGolden(name)
+
+	ctx := context.Background()
+
+	g1 := testDB.EnableGolden(name)
+	tx, err := g1.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	_, _ = tx.Exec(ctx, "INSERT INTO golden_commit_rollback (name) VALUES ($1)", "x")
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	g1.AssertGolden(t, name)
+	if t.Failed() {
+		t.Fatalf("baseline run should pass")
+	}
+
+	g2 := testDB.EnableGolden(name)
+	tx2, err := g2.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	_, _ = tx2.Exec(ctx, "INSERT INTO golden_commit_rollback (name) VALUES ($1)", "x")
+	if err := tx2.Rollback(ctx); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+
+	mt := &capturingT{}
+	assertGolden(mt, g2.recorder)
+	if !mt.failed {
+		t.Errorf("expected mismatch when COMMIT becomes ROLLBACK")
+	}
+}
+
+func TestGolden_TransactionPreservesOrder(t *testing.T) {
+	testDB := RequireDB(t)
+	if testDB == nil {
+		return
+	}
+	withGoldenSchema(t, testDB, "golden_tx_order")
+	const name = "TestGolden_TransactionPreservesOrder"
+	defer CleanupGolden(name)
+	_ = CleanupGolden(name)
+
+	ctx := context.Background()
+	g := testDB.EnableGolden(name)
+
+	tx, err := g.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if _, err := tx.Exec(ctx, "INSERT INTO golden_tx_order (name) VALUES ($1)", "first"); err != nil {
+		t.Fatalf("exec1: %v", err)
+	}
+	if _, err := tx.Exec(ctx, "INSERT INTO golden_tx_order (name) VALUES ($1)", "second"); err != nil {
+		t.Fatalf("exec2: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	g.AssertGolden(t, name)
+	if t.Failed() {
+		return
+	}
+
+	data := readGoldenFile(t, name)
+	var events []map[string]any
+	if err := json.Unmarshal(data, &events); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(events) != 4 {
+		t.Fatalf("expected 4 events, got %d: %s", len(events), data)
+	}
+	want := []string{"BEGIN", "QUERY", "QUERY", "COMMIT"}
+	for i, w := range want {
+		if got := events[i]["event"]; got != w {
+			t.Errorf("event[%d] = %v, want %s", i, got, w)
+		}
+	}
+}
+
+func TestGolden_NormalizesUUIDsTimestampsAndIDs(t *testing.T) {
+	r := newTranscriptRecorder("normalize-test")
+
+	now := time.Now()
+	u := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	r.recordQuery("SELECT 1",
+		[]any{u, now, "22222222-2222-2222-2222-222222222222"},
+		[]map[string]any{
+			r.normalizeRow([]string{"id", "user_id", "name", "created_at"},
+				[]any{int64(7), int64(7), "Alice", now}),
+			r.normalizeRow([]string{"id", "user_id", "name", "created_at"},
+				[]any{int64(8), int64(7), "Bob", now}),
+		})
+
+	if len(r.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(r.events))
+	}
+	ev := r.events[0]
+	if ev.Args[0] != "<UUID:1>" {
+		t.Errorf("args[0] = %v, want <UUID:1>", ev.Args[0])
+	}
+	if ev.Args[1] != "<TIMESTAMP>" {
+		t.Errorf("args[1] = %v, want <TIMESTAMP>", ev.Args[1])
+	}
+	if ev.Args[2] != "<UUID:2>" {
+		t.Errorf("args[2] = %v, want <UUID:2>", ev.Args[2])
+	}
+	if ev.Rows[0]["id"] != "<ID:1>" {
+		t.Errorf("rows[0].id = %v, want <ID:1>", ev.Rows[0]["id"])
+	}
+	if ev.Rows[0]["user_id"] != "<ID:1>" {
+		t.Errorf("rows[0].user_id = %v, want <ID:1> (same numeric value)", ev.Rows[0]["user_id"])
+	}
+	if ev.Rows[0]["name"] != "Alice" {
+		t.Errorf("rows[0].name should not be normalized: %v", ev.Rows[0]["name"])
+	}
+	if ev.Rows[0]["created_at"] != "<TIMESTAMP>" {
+		t.Errorf("rows[0].created_at = %v, want <TIMESTAMP>", ev.Rows[0]["created_at"])
+	}
+	if ev.Rows[1]["id"] != "<ID:2>" {
+		t.Errorf("rows[1].id = %v, want <ID:2>", ev.Rows[1]["id"])
+	}
+	if ev.Rows[1]["user_id"] != "<ID:1>" {
+		t.Errorf("rows[1].user_id = %v, want <ID:1>", ev.Rows[1]["user_id"])
+	}
+}
+
+func TestGolden_CustomNormalizerRunsBeforeDefaults(t *testing.T) {
+	r := newTranscriptRecorder("custom",
+		WithGoldenNormalizer(func(v any) (any, bool) {
+			if s, ok := v.(string); ok && strings.HasPrefix(s, "ord_") {
+				return "<ORDER>", true
+			}
+			return nil, false
+		}),
+		WithGoldenNormalizer(func(v any) (any, bool) {
+			if t, ok := v.(time.Time); ok {
+				_ = t
+				return "<CUSTOM-TIME>", true
+			}
+			return nil, false
+		}),
+	)
+
+	now := time.Now()
+	out := r.normalizer.normalize(now, "")
+	if out != "<CUSTOM-TIME>" {
+		t.Errorf("custom time normalizer should run before default: got %v", out)
+	}
+	out = r.normalizer.normalize("ord_abc", "")
+	if out != "<ORDER>" {
+		t.Errorf("custom string normalizer should run: got %v", out)
+	}
+	out = r.normalizer.normalize("plain", "")
+	if out != "plain" {
+		t.Errorf("non-matching value should pass through: got %v", out)
+	}
+}
+
+func TestGolden_DDLAndSetRecordedAsQuery(t *testing.T) {
+	testDB := RequireDB(t)
+	if testDB == nil {
+		return
+	}
+	const name = "TestGolden_DDLAndSet"
+	const table = "golden_ddl_set"
+	defer CleanupGolden(name)
+	_ = CleanupGolden(name)
+	t.Cleanup(func() {
+		_, _ = testDB.Exec(context.Background(), "DROP TABLE IF EXISTS "+table)
+	})
+
+	ctx := context.Background()
+	g := testDB.EnableGolden(name)
+
+	if _, err := g.Exec(ctx, "CREATE TABLE IF NOT EXISTS "+table+" (id INT)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := g.Exec(ctx, "SET LOCAL search_path TO public"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	g.AssertGolden(t, name)
+	if t.Failed() {
+		return
+	}
+
+	data := readGoldenFile(t, name)
+	var events []map[string]any
+	if err := json.Unmarshal(data, &events); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	for i, ev := range events {
+		if ev["event"] != "QUERY" {
+			t.Errorf("event[%d] = %v, want QUERY", i, ev["event"])
+		}
+	}
+}
+
+func TestGolden_OverwriteFlagRegeneratesBaseline(t *testing.T) {
+	testDB := RequireDB(t)
+	if testDB == nil {
+		return
+	}
+	withGoldenSchema(t, testDB, "golden_overwrite")
+	const name = "TestGolden_OverwriteFlag"
+	defer CleanupGolden(name)
+	_ = CleanupGolden(name)
+
+	ctx := context.Background()
+
+	g1 := testDB.EnableGolden(name)
+	_, _ = g1.Exec(ctx, "INSERT INTO golden_overwrite (name) VALUES ($1)", "alpha")
+	g1.AssertGolden(t, name)
+	if t.Failed() {
+		t.Fatalf("baseline run should pass")
+	}
+	first := readGoldenFile(t, name)
+
+	old := *overwriteGolden
+	*overwriteGolden = true
+	defer func() { *overwriteGolden = old }()
+
+	g2 := testDB.EnableGolden(name)
+	_, _ = g2.Exec(ctx, "INSERT INTO golden_overwrite (name) VALUES ($1)", "beta")
+	_, _ = g2.Exec(ctx, "INSERT INTO golden_overwrite (name) VALUES ($1)", "gamma")
+	g2.AssertGolden(t, name)
+	if t.Failed() {
+		t.Fatalf("overwrite run should pass")
+	}
+	second := readGoldenFile(t, name)
+	if string(first) == string(second) {
+		t.Errorf("expected baseline to be regenerated under -overwrite-golden")
+	}
+}
+
+func TestGolden_AssertWithoutEnableFails(t *testing.T) {
+	db := &DB{hooks: newHooks()}
+	mt := &capturingT{}
+	db.assertGolden(mt, "any")
+	if !mt.failed {
+		t.Errorf("expected error when calling AssertGolden without EnableGolden")
+	}
+	if !strings.Contains(mt.errorMsg, "active golden recorder") {
+		t.Errorf("unexpected message: %s", mt.errorMsg)
+	}
+}
+
+func TestGolden_NameMismatchFails(t *testing.T) {
+	db := &DB{hooks: newHooks(), recorder: newTranscriptRecorder("expected")}
+	mt := &capturingT{}
+	db.assertGolden(mt, "different")
+	if !mt.failed {
+		t.Errorf("expected error when AssertGolden name does not match recorder name")
+	}
+	if !strings.Contains(mt.errorMsg, "does not match recorder testName") {
+		t.Errorf("unexpected message: %s", mt.errorMsg)
+	}
+}
+
+func TestGolden_CleanupRemovesFile(t *testing.T) {
+	testDB := RequireDB(t)
+	if testDB == nil {
+		return
+	}
+	withGoldenSchema(t, testDB, "golden_cleanup")
+	const name = "TestGolden_CleanupRemovesFile"
+	_ = CleanupGolden(name)
+
+	ctx := context.Background()
+	g := testDB.EnableGolden(name)
+	_, _ = g.Exec(ctx, "INSERT INTO golden_cleanup (name) VALUES ($1)", "x")
+	g.AssertGolden(t, name)
+	if !goldenFileExists(name) {
+		t.Fatalf("expected golden file to exist before cleanup")
+	}
+	if err := CleanupGolden(name); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	if goldenFileExists(name) {
+		t.Errorf("expected golden file to be removed after CleanupGolden")
+	}
+	if err := CleanupGolden(name); err != nil {
+		t.Errorf("CleanupGolden should be idempotent: %v", err)
+	}
+}
+
+func TestGolden_QueryRowReturnsErrNoRowsOnEmpty(t *testing.T) {
+	testDB := RequireDB(t)
+	if testDB == nil {
+		return
+	}
+	withGoldenSchema(t, testDB, "golden_no_rows")
+	const name = "TestGolden_QueryRowEmpty"
+	defer CleanupGolden(name)
+	_ = CleanupGolden(name)
+
+	ctx := context.Background()
+	g := testDB.EnableGolden(name)
+
+	var n int
+	err := g.QueryRow(ctx, "SELECT id FROM golden_no_rows WHERE id = $1", 999).Scan(&n)
+	if err == nil {
+		t.Fatalf("expected error scanning empty result")
+	}
+	if err != pgx.ErrNoRows {
+		t.Errorf("expected pgx.ErrNoRows, got %v", err)
+	}
+	g.AssertGolden(t, name)
+}
+
+// capturingT mimics enough of *testing.T for assertGolden to drive into
+// without polluting the real test result.
+type capturingT struct {
+	failed   bool
+	errorMsg string
+	logs     []string
+}
+
+func (c *capturingT) Errorf(format string, args ...any) {
+	c.failed = true
+	c.errorMsg = fmt.Sprintf(format, args...)
+}
+
+func (c *capturingT) Logf(format string, args ...any) {
+	c.logs = append(c.logs, fmt.Sprintf(format, args...))
+}
+
+func (c *capturingT) Helper() {}

--- a/test_db.go
+++ b/test_db.go
@@ -379,10 +379,13 @@ func RequireDB(t *testing.T) *TestDB {
 	return testDB
 }
 
-// CleanupPlan removes all plan-regression files for the specified test name.
-// This includes both the captured query plan file and its baseline file
-// from the testdata/plans directory.
-func CleanupPlan(testName string) error {
+// cleanupPlan removes all plan-regression files for the specified test name —
+// both the captured plan file and its baseline. Used internally by pgxkit's
+// own tests so generated baselines don't pollute the repo. Not part of the
+// public API: end users should let baselines persist (that's the whole point
+// of plan-regression testing) and remove a baseline file by hand if they
+// want to invalidate it.
+func cleanupPlan(testName string) error {
 	if testName == "" {
 		return nil
 	}

--- a/test_db.go
+++ b/test_db.go
@@ -81,6 +81,66 @@ func (tdb *TestDB) Clean() error {
 	return nil
 }
 
+// EnableGolden returns a new DB instance that records every database event
+// (BEGIN, QUERY, COMMIT, ROLLBACK) the test scenario produces, including
+// SQL, normalized args, and materialized result rows. Call AssertGolden
+// after the scenario to compare the transcript against
+// testdata/golden/<testName>.json. Pass GoldenOption values (for example
+// WithGoldenNormalizer) to extend or override the default normalization.
+//
+// Example:
+//
+//	golden := testDB.EnableGolden("TestCreateOrder")
+//	// run the code under test using golden as the DB
+//	golden.AssertGolden(t, "TestCreateOrder")
+func (tdb *TestDB) EnableGolden(testName string, opts ...GoldenOption) *DB {
+	return &DB{
+		readPool:  tdb.readPool,
+		writePool: tdb.writePool,
+		hooks:     newHooks(),
+		recorder:  newTranscriptRecorder(testName, opts...),
+	}
+}
+
+// AssertGolden compares the captured transcript against
+// testdata/golden/<testName>.json. On the first run (or with -overwrite-golden)
+// it writes the baseline and logs that fact. On subsequent runs it fails the
+// test with a unified diff if the transcript has changed. testName must match
+// the name passed to EnableGolden.
+func (db *DB) AssertGolden(t *testing.T, testName string) {
+	t.Helper()
+	db.assertGolden(t, testName)
+}
+
+// assertGolden is the implementation behind AssertGolden, taking the smaller
+// goldenT interface so it can be exercised by capturing fakes in tests.
+func (db *DB) assertGolden(t goldenT, testName string) {
+	t.Helper()
+	if db.recorder == nil {
+		t.Errorf("AssertGolden called on a DB without an active golden recorder; use TestDB.EnableGolden first")
+		return
+	}
+	if db.recorder.testName != testName {
+		t.Errorf("AssertGolden testName %q does not match recorder testName %q", testName, db.recorder.testName)
+		return
+	}
+	assertGolden(t, db.recorder)
+}
+
+// CleanupGolden removes the golden transcript file for the named scenario.
+// Tests that create golden files should defer this call so the file does
+// not survive an isolated test run.
+func CleanupGolden(testName string) error {
+	if testName == "" {
+		return nil
+	}
+	path := goldenPath(testName)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove golden file %s: %w", path, err)
+	}
+	return nil
+}
+
 // EnableAssertPlan returns a new DB instance configured to capture query
 // plans for plan-regression testing. For each eligible query, it issues an
 // EXPLAIN (FORMAT JSON, COSTS OFF) and records the structural plan so it

--- a/test_db.go
+++ b/test_db.go
@@ -127,10 +127,13 @@ func (db *DB) assertGolden(t goldenT, testName string) {
 	assertGolden(t, db.recorder)
 }
 
-// CleanupGolden removes the golden transcript file for the named scenario.
-// Tests that create golden files should defer this call so the file does
-// not survive an isolated test run.
-func CleanupGolden(testName string) error {
+// cleanupGolden removes the golden transcript file for the named scenario.
+// Used internally by pgxkit's own tests so generated baselines don't pollute
+// the repo. Not part of the public API — end users should let baselines
+// persist across runs (that's the whole point of golden testing) and use
+// the -overwrite-golden flag to regenerate, or `rm` the file directly to
+// invalidate it.
+func cleanupGolden(testName string) error {
 	if testName == "" {
 		return nil
 	}

--- a/test_db_test.go
+++ b/test_db_test.go
@@ -102,7 +102,7 @@ func TestAssertPlan(t *testing.T) {
 	planDB.AssertPlan(t, "TestAssertPlan")
 
 	// Clean up
-	defer CleanupPlan("TestAssertPlan")
+	defer cleanupPlan("TestAssertPlan")
 }
 
 func TestCleanupPlan(t *testing.T) {
@@ -133,9 +133,9 @@ func TestCleanupPlan(t *testing.T) {
 	defer os.Chdir(originalDir)
 
 	// Test cleanup
-	err := CleanupPlan("TestCleanup")
+	err := cleanupPlan("TestCleanup")
 	if err != nil {
-		t.Errorf("CleanupPlan should not return error: %v", err)
+		t.Errorf("cleanupPlan should not return error: %v", err)
 	}
 
 	// Verify files were removed
@@ -197,7 +197,7 @@ func TestPlanDML(t *testing.T) {
 
 	t.Run("insert", func(t *testing.T) {
 		planDB := testDB.EnableAssertPlan("TestPlanDML_Insert")
-		defer CleanupPlan("TestPlanDML_Insert")
+		defer cleanupPlan("TestPlanDML_Insert")
 
 		var id int
 		err := planDB.QueryRow(ctx, `
@@ -218,7 +218,7 @@ func TestPlanDML(t *testing.T) {
 
 	t.Run("update", func(t *testing.T) {
 		planDB := testDB.EnableAssertPlan("TestPlanDML_Update")
-		defer CleanupPlan("TestPlanDML_Update")
+		defer cleanupPlan("TestPlanDML_Update")
 
 		_, err := planDB.Exec(ctx, `
 			UPDATE plan_test_users
@@ -234,7 +234,7 @@ func TestPlanDML(t *testing.T) {
 
 	t.Run("delete", func(t *testing.T) {
 		planDB := testDB.EnableAssertPlan("TestPlanDML_Delete")
-		defer CleanupPlan("TestPlanDML_Delete")
+		defer cleanupPlan("TestPlanDML_Delete")
 
 		_, err := planDB.Exec(ctx, `
 			DELETE FROM plan_test_users
@@ -272,7 +272,7 @@ func TestPlanCTE(t *testing.T) {
 
 	t.Run("cte_select", func(t *testing.T) {
 		planDB := testDB.EnableAssertPlan("TestPlanCTE_Select")
-		defer CleanupPlan("TestPlanCTE_Select")
+		defer cleanupPlan("TestPlanCTE_Select")
 
 		rows, err := planDB.Query(ctx, `
 			WITH numbered AS (
@@ -291,7 +291,7 @@ func TestPlanCTE(t *testing.T) {
 
 	t.Run("cte_insert", func(t *testing.T) {
 		planDB := testDB.EnableAssertPlan("TestPlanCTE_Insert")
-		defer CleanupPlan("TestPlanCTE_Insert")
+		defer cleanupPlan("TestPlanCTE_Insert")
 
 		_, err := planDB.Exec(ctx, `
 			WITH vals AS (
@@ -356,5 +356,5 @@ func TestTestDBIntegration(t *testing.T) {
 	planDB.AssertPlan(t, "TestIntegration")
 
 	// Clean up plan files
-	defer CleanupPlan("TestIntegration")
+	defer cleanupPlan("TestIntegration")
 }

--- a/tx.go
+++ b/tx.go
@@ -31,6 +31,7 @@ var _ Executor = (*Tx)(nil)
 type Tx struct {
 	tx        pgx.Tx
 	db        *DB
+	recorder  *transcriptRecorder
 	finalized atomic.Bool
 }
 
@@ -40,7 +41,14 @@ func (t *Tx) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Ro
 	if t.finalized.Load() {
 		return nil, ErrTxFinalized
 	}
-	return t.tx.Query(ctx, sql, args...)
+	rows, err := t.tx.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	if t.recorder != nil {
+		return captureRowsForGolden(rows, t.recorder, sql, args)
+	}
+	return rows, nil
 }
 
 // QueryRow executes a query that returns a single row within the transaction.
@@ -48,6 +56,17 @@ func (t *Tx) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Ro
 func (t *Tx) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
 	if t.finalized.Load() {
 		return &finalizedRow{}
+	}
+	if t.recorder != nil {
+		rows, err := t.tx.Query(ctx, sql, args...)
+		if err != nil {
+			return &shutdownRow{err: err}
+		}
+		replay, recordErr := captureRowsForGolden(rows, t.recorder, sql, args)
+		if recordErr != nil {
+			return &shutdownRow{err: recordErr}
+		}
+		return &replayRow{rows: replay}
 	}
 	return t.tx.QueryRow(ctx, sql, args...)
 }
@@ -58,7 +77,11 @@ func (t *Tx) Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.
 	if t.finalized.Load() {
 		return pgconn.CommandTag{}, ErrTxFinalized
 	}
-	return t.tx.Exec(ctx, sql, args...)
+	tag, err := t.tx.Exec(ctx, sql, args...)
+	if err == nil && t.recorder != nil {
+		t.recorder.recordExec(sql, args, tag.RowsAffected())
+	}
+	return tag, err
 }
 
 // Commit commits the transaction.
@@ -72,6 +95,9 @@ func (t *Tx) Commit(ctx context.Context) error {
 	defer t.db.activeOps.Done()
 
 	err := t.tx.Commit(ctx)
+	if t.recorder != nil {
+		t.recorder.recordCommit(err)
+	}
 	hookErr := t.db.hooks.executeAfterTransaction(ctx, TxCommit, nil, err)
 	if hookErr != nil {
 		if err != nil {
@@ -93,6 +119,9 @@ func (t *Tx) Rollback(ctx context.Context) error {
 	defer t.db.activeOps.Done()
 
 	err := t.tx.Rollback(ctx)
+	if t.recorder != nil {
+		t.recorder.recordRollback(err)
+	}
 	hookErr := t.db.hooks.executeAfterTransaction(ctx, TxRollback, nil, err)
 	if hookErr != nil {
 		if err != nil {


### PR DESCRIPTION
## Summary

Adds the `EnableGolden` / `AssertGolden` API specified in #69. A scenario records an ordered transcript of every database event (`BEGIN`, every `QUERY`/`Exec` with SQL + args + result rows, `COMMIT`/`ROLLBACK`); subsequent runs assert against the recorded baseline at `testdata/golden/<name>.json`.

Distinct from the `AssertPlan` plan-regression feature (#68) — this captures *behavior*, not query-plan structure.

- New `golden.go` — recorder, normalizer, transcript types, `-overwrite-golden` flag, file I/O, `go-difflib` unified-diff comparison.
- New `golden_rows.go` — buffered `pgx.Rows` replay so the caller still iterates normally after capture.
- `db.go` / `tx.go` get an unexported `recorder` field and capture-on-success in the executeQuery/executeQueryRow/executeExec/BeginTx/Commit/Rollback paths. No changes to the public hook API.
- `test_db.go` adds `EnableGolden`, `AssertGolden`, `CleanupGolden` mirroring the shape of the existing plan API.
- One new dependency: `github.com/pmezard/go-difflib` (zero-dep, same library `goldie` uses).

### Normalization defaults

- `time.Time` → `<TIMESTAMP>`
- UUIDs (`uuid.UUID`, `[16]byte`, canonical-string) → `<UUID:N>` (first-seen, scenario-scoped)
- Sequence-style IDs in row columns named `id` or ending in `_id` → `<ID:N>` (first-seen by value)
- `WithGoldenNormalizer(fn)` registers user-defined normalizers that run before defaults

### `-overwrite-golden`

Package-level `flag.Bool`. Per-call scope: only the goldens for tests that actually execute are rewritten — `go test -overwrite-golden -run TestFoo` touches only `TestFoo.json`.

### Out of scope (per the issue)

- Concurrent fan-out within one scenario.
- Mock/replay layer.
- Plan capture (separate feature, `AssertPlan`).
- `replayRows.RawValues()` and `Conn()` return `nil` — documented limitation of the materialize-and-replay tradeoff.

Closes #69

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — full suite passes, including 16 new tests covering: baseline creation, no-diff replay, behavior changes (extra/missing/different/COMMIT→ROLLBACK), multi-statement transaction order, normalization defaults, custom normalizer ordering, DDL/SET captured as QUERY, `-overwrite-golden` regeneration, error paths, `CleanupGolden`, `QueryRow` `pgx.ErrNoRows` on empty.
- [ ] CI green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)