### PR TITLE
chore: pin golangci-lint per-project via Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,8 @@ jobs:
       with:
         go-version: '1.26'
 
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v9
-      with:
-        version: latest
-        args: --timeout=5m
+    - name: Run lint
+      run: make lint
 
   security:
     name: Security Scan

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.so
 *.dylib
 
+# Project-local tool installs (golangci-lint pinned by Makefile)
+bin/
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,14 @@ TEST_DATABASE_URL = postgres://postgres:postgres@localhost:$(TEST_DB_PORT)/testd
 
 GO_TEST_FLAGS ?= -v -race -parallel=1
 
+# Pinned per-project so local and CI run the exact same binary regardless of
+# whatever golangci-lint anyone has installed globally. Bump by editing the
+# version, then `make lint` installs it on next invocation.
+GOLANGCI_VERSION := v2.12.1
+LOCAL_BIN        := $(CURDIR)/bin
+GOLANGCI         := $(LOCAL_BIN)/golangci-lint
+GOLANGCI_STAMP   := $(LOCAL_BIN)/.golangci-lint-$(GOLANGCI_VERSION)
+
 .PHONY: help test-db-up test-db-down test test-coverage coverage-html lint bench
 
 help: ## Show available targets
@@ -32,8 +40,15 @@ test-coverage: test-db-up ## Run the test suite and write coverage.out
 coverage-html: ## Open coverage.out in the browser (run after test-coverage)
 	go tool cover -html=coverage.out
 
-lint: ## Run golangci-lint
-	golangci-lint run --timeout=5m
+# Stamp file embeds the version, so bumping GOLANGCI_VERSION rebuilds the bin.
+$(GOLANGCI_STAMP):
+	@mkdir -p $(LOCAL_BIN)
+	@rm -f $(LOCAL_BIN)/.golangci-lint-* $(GOLANGCI)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_VERSION)/install.sh | sh -s -- -b $(LOCAL_BIN) $(GOLANGCI_VERSION)
+	@touch $(GOLANGCI_STAMP)
+
+lint: $(GOLANGCI_STAMP) ## Run pinned golangci-lint
+	$(GOLANGCI) run --timeout=5m
 
 bench: test-db-up ## Run benchmarks against the local test DB
 	@TEST_DATABASE_URL="$(TEST_DATABASE_URL)" go test -bench=. -benchmem -run=^$$ ./...


### PR DESCRIPTION
## Summary

Pins `golangci-lint` to a specific version in the Makefile and installs it into `./bin` on `make lint`, so local and CI run the exact same binary regardless of whatever's globally installed. Avoids the local/CI drift that surfaced on #75 (CI's `version: latest` shipped a new `govet` analyzer that the older brew-installed local version didn't run).

- `Makefile` — `GOLANGCI_VERSION := v2.12.1`, install via the upstream install script into `./bin`, gated by a version-tagged stamp file so bumping the version triggers a clean reinstall.
- `.github/workflows/ci.yml` — lint job calls `make lint` instead of `golangci-lint-action@v9`.
- `.gitignore` — adds `bin/` so the local install isn't committed.

Bumping is one line: edit `GOLANGCI_VERSION`, run `make lint`, commit.

## Test plan

- [x] `make lint` from a clean checkout downloads `v2.12.1` into `./bin` and runs against the existing code with 0 issues.
- [x] Re-running `make lint` reuses the installed binary (no re-download).
- [ ] CI green on this PR confirms the workflow change works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)