### PR TITLE
fix(plan): in-memory capture, single baseline, unified diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,17 +304,14 @@ func TestUserQueries(t *testing.T) {
     testDB.Setup()
     defer testDB.Clean()
 
-    // Enable plan-regression hooks - captures EXPLAIN (FORMAT JSON, COSTS OFF) plans automatically
     db := testDB.EnableAssertPlan("TestUserQueries")
 
-    // These queries will have their structural plans captured
     rows, err := db.Query(ctx, "SELECT * FROM users WHERE active = true")
     // ... more queries
 
-    // Plans are saved to testdata/plans/TestUserQueries_query_1.json, etc.
-    // Future runs assert the plan shape is unchanged (e.g. seq-scan vs index-scan,
-    // nested-loop vs hash-join, new sort node, different join order).
-    // This does NOT assert anything about query result rows.
+    // First run writes testdata/plans/TestUserQueries.json; later runs fail
+    // with a unified diff on plan-shape change. Regenerate with `go test -overwrite-plan`.
+    db.AssertPlan(t, "TestUserQueries")
 }
 ```
 

--- a/db.go
+++ b/db.go
@@ -177,6 +177,7 @@ type DB struct {
 	writePool *pgxpool.Pool
 	hooks     *hooks
 	recorder  *transcriptRecorder
+	planHook  *assertPlanHook
 	mu        sync.RWMutex
 	shutdown  bool
 	activeOps sync.WaitGroup

--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -828,7 +828,7 @@ func TestUserQueries(t *testing.T) {
 func (tdb *TestDB) EnableAssertPlan(testName string) *DB
 ```
 
-Enables plan-regression testing. Captures the structural query plan via `EXPLAIN (FORMAT JSON, COSTS OFF)` and asserts it is unchanged across runs. This catches plan shape changes such as seq-scan to index-scan, nested-loop to hash-join, a new sort node, or a different join order. It does NOT assert anything about query result rows. Because the captured form is plan-only (no `ANALYZE`), the underlying query is not executed during plan capture and there are no side effects to roll back.
+Enables plan-regression testing. Captures the structural query plan via `EXPLAIN (FORMAT JSON, COSTS OFF)` for each eligible query (SELECT/INSERT/UPDATE/DELETE/WITH) and accumulates them in memory. Call `AssertPlan` after the scenario to compare the captured plans against `testdata/plans/<testName>.json`. This catches plan shape changes such as seq-scan to index-scan, nested-loop to hash-join, a new sort node, or a different join order. It does NOT assert anything about query result rows. Because the captured form is plan-only (no `ANALYZE`), the underlying query is not executed during plan capture and there are no side effects to roll back.
 
 **Example:**
 ```go
@@ -850,8 +850,18 @@ func TestUserQueries(t *testing.T) {
     // DML queries are also captured. EXPLAIN without ANALYZE plans the
     // statement without executing it, so plan capture has no side effects.
     db.Exec(ctx, "UPDATE users SET last_login = NOW() WHERE id = $1", userID)
+
+    db.AssertPlan(t, "TestUserQueries")
 }
 ```
+
+### AssertPlan
+
+```go
+func (db *DB) AssertPlan(t *testing.T, testName string)
+```
+
+Compares the in-memory plans captured by `EnableAssertPlan` against `testdata/plans/<testName>.json`. On the first run (or with `go test -overwrite-plan`) it writes the baseline and logs that fact. On subsequent runs it fails the test with a unified diff if the plans have changed. `testName` must match the name passed to `EnableAssertPlan`.
 
 ### EnableGolden
 

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -256,6 +256,8 @@ func TestComplexQuery_Plan(t *testing.T) {
     rows, err := db.Query(ctx, complexQuery)
     require.NoError(t, err)
     defer rows.Close()
+
+    db.AssertPlan(t, "TestComplexQuery")
 }
 ```
 

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -564,6 +564,8 @@ func TestUserQueries(t *testing.T) {
     // Plan-regression test will assert the structural query plan is unchanged.
     // Result rows are NOT compared - assert those yourself.
     require.Len(t, users, 3)
+
+    db.AssertPlan(t, "TestUserQueries")
 }
 ```
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -282,6 +282,8 @@ func TestComplexQuery_Plan(t *testing.T) {
     `)
     require.NoError(t, err)
     defer rows.Close()
+
+    db.AssertPlan(t, "TestComplexQuery")
 }
 ```
 

--- a/docs/Performance-Guide.md
+++ b/docs/Performance-Guide.md
@@ -588,6 +588,8 @@ func TestQueryPerformance(t *testing.T) {
             t.Error("Expected search results")
         }
     })
+
+    db.AssertPlan(t, "TestQueryPerformance")
 }
 ```
 

--- a/docs/Testing-Guide.md
+++ b/docs/Testing-Guide.md
@@ -501,6 +501,8 @@ func TestUserQueries_Plan(t *testing.T) {
         `)
         require.NoError(t, err)
     })
+
+    db.AssertPlan(t, "TestUserQueries_Plan")
 }
 ```
 
@@ -560,6 +562,8 @@ func TestPerformanceRegression(t *testing.T) {
         // Wall-clock duration is asserted explicitly above; the
         // plan-regression test does not measure execution time.
     })
+
+    db.AssertPlan(t, "TestPerformanceRegression")
 }
 ```
 

--- a/golden.go
+++ b/golden.go
@@ -324,21 +324,19 @@ func marshalEvents(events []transcriptEvent) ([]byte, error) {
 	return data, nil
 }
 
-// writeGolden writes pretty-printed transcript bytes, creating the directory.
-func writeGolden(path string, data []byte) error {
+// writeBaseline writes bytes to path, creating the directory.
+func writeBaseline(path string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("failed to create golden directory: %w", err)
+		return fmt.Errorf("failed to create baseline directory: %w", err)
 	}
 	if err := os.WriteFile(path, data, 0o644); err != nil {
-		return fmt.Errorf("failed to write golden file %s: %w", path, err)
+		return fmt.Errorf("failed to write baseline file %s: %w", path, err)
 	}
 	return nil
 }
 
-// compareGolden compares baseline to current bytes. If they match, ok is true
-// and diff is empty. Otherwise diff is a unified diff string. Extracted as a
-// pure function so it can be unit tested without a *testing.T.
-func compareGolden(path string, baseline, current []byte) (string, bool) {
+// unifiedDiff returns ("", true) if equal, otherwise (diff, false).
+func unifiedDiff(path string, baseline, current []byte) (string, bool) {
 	if bytes.Equal(baseline, current) {
 		return "", true
 	}
@@ -378,7 +376,7 @@ func assertGolden(t goldenT, recorder *transcriptRecorder) {
 	missing := os.IsNotExist(statErr)
 
 	if missing || (overwriteGolden != nil && *overwriteGolden) {
-		if err := writeGolden(path, current); err != nil {
+		if err := writeBaseline(path, current); err != nil {
 			t.Errorf("%v", err)
 			return
 		}
@@ -396,7 +394,7 @@ func assertGolden(t goldenT, recorder *transcriptRecorder) {
 		return
 	}
 
-	diff, ok := compareGolden(path, baseline, current)
+	diff, ok := unifiedDiff(path, baseline, current)
 	if ok {
 		return
 	}

--- a/test_db.go
+++ b/test_db.go
@@ -3,6 +3,7 @@ package pgxkit
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -144,18 +145,11 @@ func cleanupGolden(testName string) error {
 	return nil
 }
 
-// EnableAssertPlan returns a new DB instance configured to capture query
-// plans for plan-regression testing. For each eligible query, it issues an
-// EXPLAIN (FORMAT JSON, COSTS OFF) and records the structural plan so it
-// can be diffed against a baseline. The testName is used to name the plan
-// file under testdata/plans. Use AssertPlan after test execution to compare
-// captured plans against the baseline.
-//
-// Example:
-//
-//	planDB := testDB.EnableAssertPlan("user_queries")
-//	// run queries using planDB
-//	planDB.AssertPlan(t, "user_queries")
+var overwritePlan = flag.Bool("overwrite-plan", false, "regenerate testdata/plans baselines instead of asserting")
+
+// EnableAssertPlan returns a *DB that captures the structural EXPLAIN plan
+// of each SELECT/INSERT/UPDATE/DELETE/WITH query into memory. Call AssertPlan
+// to compare against testdata/plans/<testName>.json.
 func (tdb *TestDB) EnableAssertPlan(testName string) *DB {
 	planDB := &DB{
 		readPool:  tdb.readPool,
@@ -164,46 +158,38 @@ func (tdb *TestDB) EnableAssertPlan(testName string) *DB {
 	}
 
 	planHook := &assertPlanHook{
-		testName:     testName,
-		queryCounter: 0,
-		mu:           sync.Mutex{},
-		db:           planDB,
+		testName: testName,
+		db:       planDB,
 	}
-
+	planDB.planHook = planHook
 	planDB.hooks.addHook(BeforeOperation, planHook.captureExplainPlan)
 
 	return planDB
 }
 
-// assertPlanHook handles plan-regression assertion functionality.
 type assertPlanHook struct {
-	testName     string
-	queryCounter int
-	mu           sync.Mutex
-	db           *DB
+	testName string
+	mu       sync.Mutex
+	plans    []QueryPlan
+	db       *DB
 }
 
-// QueryPlan represents a captured structural query plan.
-// It stores the SQL statement and the JSON plan output for use in
-// plan-regression comparisons.
+// QueryPlan is one captured structural query plan.
 type QueryPlan struct {
 	Query int                      `json:"query"`
 	SQL   string                   `json:"sql"`
 	Plan  []map[string]interface{} `json:"plan"`
 }
 
-// captureExplainPlan captures structural EXPLAIN plans for queries.
 func (g *assertPlanHook) captureExplainPlan(ctx context.Context, sql string, args []interface{}, operationErr error) error {
-	if g.db == nil {
+	if g.db == nil || g.db.writePool == nil {
 		return nil
 	}
 
 	upperSQL := strings.ToUpper(strings.TrimSpace(sql))
-
 	if strings.HasPrefix(upperSQL, "EXPLAIN") {
 		return nil
 	}
-
 	if !strings.HasPrefix(upperSQL, "SELECT") &&
 		!strings.HasPrefix(upperSQL, "INSERT") &&
 		!strings.HasPrefix(upperSQL, "UPDATE") &&
@@ -212,28 +198,16 @@ func (g *assertPlanHook) captureExplainPlan(ctx context.Context, sql string, arg
 		return nil
 	}
 
-	g.mu.Lock()
-	g.queryCounter++
-	currentQuery := g.queryCounter
-	g.mu.Unlock()
-
 	explainSQL := fmt.Sprintf("EXPLAIN (FORMAT JSON, COSTS OFF) %s", sql)
 
-	if g.db.writePool == nil {
-		return nil
-	}
-
 	var explainResult string
-
 	rows, err := g.db.writePool.Query(ctx, explainSQL, args...)
 	if err != nil {
 		return nil
 	}
 	defer rows.Close()
-
 	if rows.Next() {
-		err = rows.Scan(&explainResult)
-		if err != nil {
+		if err := rows.Scan(&explainResult); err != nil {
 			return nil
 		}
 	}
@@ -246,118 +220,90 @@ func (g *assertPlanHook) captureExplainPlan(ctx context.Context, sql string, arg
 		return nil
 	}
 
-	queryPlan := QueryPlan{
-		Query: currentQuery,
+	g.mu.Lock()
+	g.plans = append(g.plans, QueryPlan{
+		Query: len(g.plans) + 1,
 		SQL:   sql,
 		Plan:  explainData,
-	}
-
-	err = g.appendToPlanFile(queryPlan)
-	if err != nil {
-		return nil
-	}
+	})
+	g.mu.Unlock()
 
 	return nil
 }
 
-// appendToPlanFile appends the query plan to the plan file.
-func (g *assertPlanHook) appendToPlanFile(queryPlan QueryPlan) error {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-
-	planFile := fmt.Sprintf("testdata/plans/%s.json", g.testName)
-
-	dir := filepath.Dir(planFile)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", dir, err)
-	}
-
-	var existingPlans []QueryPlan
-	if data, err := os.ReadFile(planFile); err == nil {
-		if len(data) > 0 {
-			if err := json.Unmarshal(data, &existingPlans); err != nil {
-				return fmt.Errorf("failed to parse existing plan file %s: %w", planFile, err)
-			}
-		}
-	}
-
-	existingPlans = append(existingPlans, queryPlan)
-
-	data, err := json.MarshalIndent(existingPlans, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal query plans: %w", err)
-	}
-
-	err = os.WriteFile(planFile, data, 0644)
-	if err != nil {
-		return fmt.Errorf("failed to write plan file %s: %w", planFile, err)
-	}
-
-	return nil
+func planPath(name string) string {
+	return filepath.Join("testdata", "plans", name+".json")
 }
 
-// AssertPlan compares captured query plans against a baseline file.
-// On first run, it creates a baseline file from the current plan output.
-// On subsequent runs, it compares the current plans against the baseline
-// and reports test failures for any query count, SQL, or plan changes.
+func marshalPlans(plans []QueryPlan) ([]byte, error) {
+	if plans == nil {
+		plans = []QueryPlan{}
+	}
+	data, err := json.MarshalIndent(plans, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	data = append(data, '\n')
+	return data, nil
+}
+
+// AssertPlan compares the captured plans against testdata/plans/<testName>.json,
+// writing the baseline on first run or with -overwrite-plan, and failing with
+// a unified diff on mismatch. testName must match EnableAssertPlan's.
 func (db *DB) AssertPlan(t *testing.T, testName string) {
-	planFile := fmt.Sprintf("testdata/plans/%s.json", testName)
+	t.Helper()
+	db.assertPlan(t, testName)
+}
 
-	data, err := os.ReadFile(planFile)
+func (db *DB) assertPlan(t goldenT, testName string) {
+	t.Helper()
+	if db.planHook == nil {
+		t.Errorf("AssertPlan called on a DB without an active plan hook; use TestDB.EnableAssertPlan first")
+		return
+	}
+	if db.planHook.testName != testName {
+		t.Errorf("AssertPlan testName %q does not match hook testName %q", testName, db.planHook.testName)
+		return
+	}
+
+	db.planHook.mu.Lock()
+	plans := append([]QueryPlan(nil), db.planHook.plans...)
+	db.planHook.mu.Unlock()
+
+	current, err := marshalPlans(plans)
 	if err != nil {
-		t.Errorf("Failed to read plan file %s: %v", planFile, err)
+		t.Errorf("failed to marshal plans: %v", err)
 		return
 	}
 
-	var currentPlans []QueryPlan
-	if err := json.Unmarshal(data, &currentPlans); err != nil {
-		t.Errorf("Failed to parse plan file %s: %v", planFile, err)
-		return
-	}
+	path := planPath(testName)
+	_, statErr := os.Stat(path)
+	missing := os.IsNotExist(statErr)
 
-	baselineFile := planFile + ".baseline"
-	if _, err := os.Stat(baselineFile); os.IsNotExist(err) {
-		err = os.WriteFile(baselineFile, data, 0644)
-		if err != nil {
-			t.Errorf("Failed to create baseline file: %v", err)
+	if missing || (overwritePlan != nil && *overwritePlan) {
+		if err := writeBaseline(path, current); err != nil {
+			t.Errorf("%v", err)
 			return
 		}
-		t.Logf("Created plan baseline: %s", baselineFile)
+		if missing {
+			t.Logf("created plan baseline: %s", path)
+		} else {
+			t.Logf("regenerated plan baseline: %s", path)
+		}
 		return
 	}
 
-	baselineData, err := os.ReadFile(baselineFile)
+	baseline, err := os.ReadFile(path)
 	if err != nil {
-		t.Errorf("Failed to read baseline file %s: %v", baselineFile, err)
+		t.Errorf("failed to read plan file %s: %v", path, err)
 		return
 	}
 
-	var baselinePlans []QueryPlan
-	if err := json.Unmarshal(baselineData, &baselinePlans); err != nil {
-		t.Errorf("Failed to parse baseline file %s: %v", baselineFile, err)
+	diff, ok := unifiedDiff(path, baseline, current)
+	if ok {
 		return
 	}
-
-	if len(currentPlans) != len(baselinePlans) {
-		t.Errorf("Query count mismatch: expected %d queries, got %d", len(baselinePlans), len(currentPlans))
-		return
-	}
-
-	for i, current := range currentPlans {
-		baseline := baselinePlans[i]
-
-		if current.SQL != baseline.SQL {
-			t.Errorf("Query %d SQL mismatch:\nExpected: %s\nGot: %s", i+1, baseline.SQL, current.SQL)
-			continue
-		}
-
-		currentPlanJSON, _ := json.Marshal(current.Plan)
-		baselinePlanJSON, _ := json.Marshal(baseline.Plan)
-
-		if string(currentPlanJSON) != string(baselinePlanJSON) {
-			t.Errorf("Query %d plan regression detected:\nSQL: %s\nPlan changed from baseline", i+1, current.SQL)
-		}
-	}
+	t.Errorf("plan regression for %s\n%s", path, diff)
 }
 
 // RequireDB ensures a test database is available or skips the test.
@@ -379,27 +325,14 @@ func RequireDB(t *testing.T) *TestDB {
 	return testDB
 }
 
-// cleanupPlan removes all plan-regression files for the specified test name —
-// both the captured plan file and its baseline. Used internally by pgxkit's
-// own tests so generated baselines don't pollute the repo. Not part of the
-// public API: end users should let baselines persist (that's the whole point
-// of plan-regression testing) and remove a baseline file by hand if they
-// want to invalidate it.
+// cleanupPlan removes a plan baseline file. Internal helper for pgxkit tests.
 func cleanupPlan(testName string) error {
 	if testName == "" {
 		return nil
 	}
-
-	files := []string{
-		fmt.Sprintf("testdata/plans/%s.json", testName),
-		fmt.Sprintf("testdata/plans/%s.json.baseline", testName),
+	path := planPath(testName)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove plan file %s: %w", path, err)
 	}
-
-	for _, file := range files {
-		if err := os.Remove(file); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed to remove plan file %s: %w", file, err)
-		}
-	}
-
 	return nil
 }

--- a/test_db_test.go
+++ b/test_db_test.go
@@ -3,7 +3,6 @@ package pgxkit
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"testing"
 )
 
@@ -105,44 +104,83 @@ func TestAssertPlan(t *testing.T) {
 	defer cleanupPlan("TestAssertPlan")
 }
 
-func TestCleanupPlan(t *testing.T) {
-	// Create temporary directory for test
-	tempDir := t.TempDir()
-
-	// Create some test plan files using the new naming pattern
-	planFiles := []string{
-		filepath.Join(tempDir, "testdata", "plans", "TestCleanup.json"),
-		filepath.Join(tempDir, "testdata", "plans", "TestCleanup.json.baseline"),
+func TestAssertPlan_RerunIsStable(t *testing.T) {
+	testDB := RequireDB(t)
+	if testDB == nil {
+		return
 	}
+	const name = "TestAssertPlan_RerunIsStable"
+	defer cleanupPlan(name)
+	_ = cleanupPlan(name)
 
-	for _, file := range planFiles {
-		err := os.MkdirAll(filepath.Dir(file), 0755)
-		if err != nil {
-			t.Fatalf("Failed to create directory: %v", err)
-		}
+	ctx := context.Background()
 
-		err = os.WriteFile(file, []byte(`[{"query": 1, "sql": "SELECT 1", "plan": []}]`), 0644)
-		if err != nil {
-			t.Fatalf("Failed to create test file: %v", err)
-		}
-	}
-
-	// Change to temp directory for cleanup
-	originalDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(originalDir)
-
-	// Test cleanup
-	err := cleanupPlan("TestCleanup")
+	p1 := testDB.EnableAssertPlan(name)
+	rows, err := p1.Query(ctx, "SELECT 1")
 	if err != nil {
-		t.Errorf("cleanupPlan should not return error: %v", err)
+		t.Fatalf("query: %v", err)
+	}
+	rows.Close()
+	p1.AssertPlan(t, name)
+	if t.Failed() {
+		t.Fatalf("baseline run should pass")
 	}
 
-	// Verify files were removed
-	for _, file := range planFiles {
-		if _, err := os.Stat(file); !os.IsNotExist(err) {
-			t.Errorf("Plan file should have been removed: %s", file)
-		}
+	p2 := testDB.EnableAssertPlan(name)
+	rows, err = p2.Query(ctx, "SELECT 1")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	rows.Close()
+	p2.AssertPlan(t, name)
+}
+
+func TestAssertPlan_OverwriteRegeneratesBaseline(t *testing.T) {
+	testDB := RequireDB(t)
+	if testDB == nil {
+		return
+	}
+	const name = "TestAssertPlan_OverwriteRegeneratesBaseline"
+	defer cleanupPlan(name)
+	_ = cleanupPlan(name)
+
+	ctx := context.Background()
+
+	p1 := testDB.EnableAssertPlan(name)
+	rows, err := p1.Query(ctx, "SELECT 1")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	rows.Close()
+	p1.AssertPlan(t, name)
+	if t.Failed() {
+		t.Fatalf("baseline run should pass")
+	}
+	first, err := os.ReadFile(planPath(name))
+	if err != nil {
+		t.Fatalf("read baseline: %v", err)
+	}
+
+	old := *overwritePlan
+	*overwritePlan = true
+	defer func() { *overwritePlan = old }()
+
+	p2 := testDB.EnableAssertPlan(name)
+	rows, err = p2.Query(ctx, "SELECT 1 AS different_alias")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	rows.Close()
+	p2.AssertPlan(t, name)
+	if t.Failed() {
+		t.Fatalf("overwrite run should pass")
+	}
+	second, err := os.ReadFile(planPath(name))
+	if err != nil {
+		t.Fatalf("read regenerated baseline: %v", err)
+	}
+	if string(first) == string(second) {
+		t.Errorf("expected baseline to be regenerated under -overwrite-plan")
 	}
 }
 


### PR DESCRIPTION
Closes #79.

## Summary
- `EnableAssertPlan` now accumulates plans **in memory** on the hook (no per-query disk write). Drops `appendToPlanFile` and its read-existing-then-append semantic that doubled the file on every re-run.
- `AssertPlan` mirrors `assertGolden`: writes `testdata/plans/<name>.json` on first run or with `-overwrite-plan`; on subsequent runs, emits a `go-difflib` unified diff. Drops the `.json.baseline` sibling and the no-context `Plan changed from baseline` message.
- New flag: `-overwrite-plan`, parallel to `-overwrite-golden`.
- Reuses the golden helpers (`writeBaseline`, `unifiedDiff`) — both features now share the same compare/write code.
- Net result for consumers: one file per scenario, no manual `os.Remove` reset helper between runs (skimatik's workaround in nhalm/skimatik#151 goes away).

## Test plan
- [x] `make lint` — clean
- [x] `make test` — all pass
- [x] `TestAssertPlan_RerunIsStable` — regression test for the bug (run-twice no longer fails)
- [x] `TestAssertPlan_OverwriteRegeneratesBaseline` — covers the new `-overwrite-plan` flag
- [x] Existing `TestAssertPlan`, `TestPlanDML`, `TestPlanCTE`, `TestTestDBIntegration` still pass

## Docs
README, API-Reference, FAQ, Examples, Contributing, Performance-Guide, and Testing-Guide updated to show the `AssertPlan(t, name)` callsite (previously omitted) and mention `-overwrite-plan`. Removed README's stale `TestUserQueries_query_1.json` path comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)