### PR TITLE
docs: prune cruft, point at pgxkit features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,21 @@
 # pgxkit
 
-[![Go Version](https://img.shields.io/github/go-mod/go-version/nhalm/pgxkit)](https://golang.org/doc/devel/release.html)
-[![CI Status](https://github.com/nhalm/pgxkit/actions/workflows/ci.yml/badge.svg)](https://github.com/nhalm/pgxkit/actions/workflows/ci.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/nhalm/pgxkit)](https://goreportcard.com/report/github.com/nhalm/pgxkit)
-[![Release](https://img.shields.io/github/v/release/nhalm/pgxkit)](https://github.com/nhalm/pgxkit/releases)
+[![CI](https://github.com/nhalm/pgxkit/actions/workflows/ci.yml/badge.svg)](https://github.com/nhalm/pgxkit/actions/workflows/ci.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/nhalm/pgxkit/v2.svg)](https://pkg.go.dev/github.com/nhalm/pgxkit/v2)
+[![Go Report Card](https://goreportcard.com/badge/github.com/nhalm/pgxkit/v2)](https://goreportcard.com/report/github.com/nhalm/pgxkit/v2)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A production-ready PostgreSQL toolkit for Go applications — tool-agnostic utilities for connection pooling, observability, testing, and type helpers.
+A focused PostgreSQL toolkit for Go, built on `pgx`. Connection pool with read/write split, an extensible hook system, retry helpers, plan-regression and golden-transcript testing, graceful shutdown, and small type helpers — and nothing else.
 
-## Overview
-
-pgxkit is a **tool-agnostic** PostgreSQL toolkit that works with any approach to PostgreSQL development:
-
-- **Raw pgx usage** - Use pgxkit directly with pgx for maximum control
-- **Any code generation tool** - Works with sqlc, Skimatik, or any other tool
-- **Clean architecture** - Separate your database layer from your business logic
-- **Production-ready** - Built-in observability, retry logic, and graceful shutdown
-
-## Key Features
-
-- 🔄 **Read/Write Pool Abstraction** - Safe by default, optimized when needed
-- 🎣 **Extensible Hook System** - Add logging, tracing, metrics, circuit breakers
-- 🔁 **Smart Retry Logic** - PostgreSQL-aware error detection and exponential backoff
-- 🧪 **Testing Infrastructure** - Plan-regression test support to catch query plan changes
-- 🔧 **Type Helpers** - Seamless pgx type conversions
-- 📊 **Health Checks** - Built-in database connectivity monitoring
-- 🛡️ **Graceful Shutdown** - Production-ready lifecycle management
-- 🔀 **Executor Interface** - Write functions that work with both `*DB` and `*Tx`
-
-## Installation
+## Install
 
 ```bash
-go get github.com/nhalm/pgxkit
+go get github.com/nhalm/pgxkit/v2
 ```
 
-## Quick Start
+Go 1.25+ · PostgreSQL 12+.
 
-### Basic Usage
+## Quick start
 
 ```go
 package main
@@ -45,446 +24,162 @@ import (
     "context"
     "log"
 
-    "github.com/nhalm/pgxkit"
+    "github.com/nhalm/pgxkit/v2"
 )
 
 func main() {
     ctx := context.Background()
-
-    // Create and connect to database
     db := pgxkit.NewDB()
-
-    // Connect using environment variables or explicit DSN
-    err := db.Connect(ctx, "") // Uses POSTGRES_* env vars
-    if err != nil {
+    if err := db.Connect(ctx, ""); err != nil { // "" → POSTGRES_* env vars
         log.Fatal(err)
     }
     defer db.Shutdown(ctx)
 
-    // Execute queries (uses write pool by default - safe)
-    _, err = db.Exec(ctx, "INSERT INTO users (name) VALUES ($1)", "John")
-    if err != nil {
+    if _, err := db.Exec(ctx, "INSERT INTO users (name) VALUES ($1)", "Alice"); err != nil {
         log.Fatal(err)
     }
-
-    // Optimize reads with explicit read pool usage
     rows, err := db.ReadQuery(ctx, "SELECT id, name FROM users")
     if err != nil {
         log.Fatal(err)
     }
     defer rows.Close()
-
-    // Process results...
 }
 ```
 
-### With Read/Write Splitting
-
-```go
-db := pgxkit.NewDB()
-
-// Connect with separate read and write pools
-err := db.ConnectReadWrite(ctx, readDSN, writeDSN)
-if err != nil {
-    log.Fatal(err)
-}
-
-// Writes go to write pool (safe by default)
-db.Exec(ctx, "INSERT INTO users ...")
-
-// Reads can use read pool for optimization
-db.ReadQuery(ctx, "SELECT * FROM users")
-```
+`Query` / `QueryRow` / `Exec` go through the write pool. `ReadQuery` / `ReadQueryRow` go through the read pool when one is configured via `ConnectReadWrite`; otherwise they share the single pool.
 
 ## Configuration
 
-### Environment Variables
-
-pgxkit uses these environment variables when no DSN is provided:
-
-- `POSTGRES_HOST` (default: "localhost")
-- `POSTGRES_PORT` (default: 5432)
-- `POSTGRES_USER` (default: "postgres")
-- `POSTGRES_PASSWORD` (default: "")
-- `POSTGRES_DB` (default: "postgres")
-- `POSTGRES_SSLMODE` (default: "disable")
-
-### DSN Utilities
+If `dsn == ""`, pgxkit builds one from `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_SSLMODE`. `pgxkit.GetDSN()` returns the same string for tools that need it externally.
 
 ```go
-// Get DSN from environment variables
-dsn := pgxkit.GetDSN()
+db.Connect(ctx, "",
+    pgxkit.WithMaxConns(25),
+    pgxkit.WithMinConns(5),
+    pgxkit.WithMaxConnLifetime(time.Hour),
+)
 
-// Use with external tools
-dsn := pgxkit.GetDSN()
+// Or with read/write split:
+db.ConnectReadWrite(ctx, replicaDSN, primaryDSN)
 ```
 
-## Hooks System
+## Hooks
 
-Add observability and custom functionality through connect options:
+`HookFunc` is `func(ctx, sql, args, tag pgconn.CommandTag, err error) error`. `tag` carries the real command tag for `AfterOperation` on Exec; it's the zero value everywhere else (including `AfterOperation` on Query — pgx doesn't fill the tag until rows are closed).
 
 ```go
-db := pgxkit.NewDB()
-err := db.Connect(ctx, dsn,
-    // Logging hook
-    pgxkit.WithBeforeOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-        log.Printf("Executing: %s", sql)
+db.Connect(ctx, "",
+    pgxkit.WithBeforeOperation(func(ctx context.Context, sql string, _ []interface{}, _ pgconn.CommandTag, _ error) error {
+        slog.InfoContext(ctx, "query", "sql", sql)
         return nil
     }),
-    // Metrics hook
-    pgxkit.WithAfterOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-        if operationErr != nil {
-            metrics.IncrementCounter("db.errors")
+    pgxkit.WithAfterOperation(func(ctx context.Context, _ string, _ []interface{}, tag pgconn.CommandTag, err error) error {
+        if err != nil {
+            metrics.QueryErrors.Inc()
+        } else if tag.String() != "" { // Exec
+            metrics.RowsAffected.Add(float64(tag.RowsAffected()))
         }
-        return nil
-    }),
-    // Connection setup
-    pgxkit.WithOnConnect(func(conn *pgx.Conn) error {
-        log.Println("New connection established")
         return nil
     }),
 )
 ```
 
-### Available Options
+Lifecycle hooks: `WithBeforeOperation`, `WithAfterOperation`, `WithBeforeTransaction`, `WithAfterTransaction`, `WithOnShutdown`. Connection-level hooks: `WithOnConnect`, `WithOnDisconnect`, `WithOnAcquire`, `WithOnRelease`.
 
-**Pool configuration:**
-- `WithMaxConns(n int32)` - Maximum connections in pool
-- `WithMinConns(n int32)` - Minimum connections in pool
-- `WithMaxConnLifetime(d time.Duration)` - Maximum connection lifetime
-- `WithMaxConnIdleTime(d time.Duration)` - Maximum idle time
+## Retry
 
-**Operation hooks:**
-- `WithBeforeOperation(fn)` - Before any query/exec
-- `WithAfterOperation(fn)` - After any query/exec
-- `WithBeforeTransaction(fn)` - Before transaction starts
-- `WithAfterTransaction(fn)` - After transaction completes
-- `WithOnShutdown(fn)` - During graceful shutdown
-
-**Connection hooks:**
-- `WithOnConnect(fn)` - When new connection is established
-- `WithOnDisconnect(fn)` - When connection is closed
-- `WithOnAcquire(fn)` - When connection is acquired from pool
-- `WithOnRelease(fn)` - When connection is returned to pool
-
-## Retry Logic
-
-### RetryOperation Function
+`RetryOperation` retries transient PostgreSQL errors (serialization failures, deadlocks, connection drops). Constraint violations and other deterministic errors pass through.
 
 ```go
-// Retry with default settings:
-// - 3 retry attempts
-// - 100ms initial delay
-// - 1s maximum delay
-// - 2x exponential backoff
 err := pgxkit.RetryOperation(ctx, func(ctx context.Context) error {
-    _, err := db.Exec(ctx, "INSERT INTO users (name, email) VALUES ($1, $2)",
-        "John Doe", "john@example.com")
+    _, err := db.Exec(ctx, "UPDATE accounts SET balance = balance - $1 WHERE id = $2", amt, id)
     return err
-})
-
-// Retry with custom configuration
-err = pgxkit.RetryOperation(ctx, func(ctx context.Context) error {
-    rows, err := db.Query(ctx, "SELECT * FROM users")
-    if err != nil {
-        return err
-    }
-    defer rows.Close()
-    // Process rows...
-    return nil
-}, pgxkit.WithMaxRetries(5), pgxkit.WithMaxDelay(5*time.Second))
-
-// Retry with timeout using context.WithTimeout
-ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-defer cancel()
-user, err := pgxkit.Retry(ctx, func(ctx context.Context) (*User, error) {
-    return getUserFromDatabase(ctx)
-}, pgxkit.WithMaxRetries(3))
+}, pgxkit.WithMaxRetries(5))
 ```
 
-### Timeout Behavior
-
-The timeout (set via `context.WithTimeout`) applies to **all retry attempts combined**, not per-attempt. If your timeout is 5 seconds and the first attempt takes 3 seconds, subsequent retries share the remaining 2 seconds.
-
-### Smart Error Detection
-
-pgxkit automatically detects which PostgreSQL errors are worth retrying:
-
-| Error Type | Retries? | Examples |
-|------------|----------|----------|
-| Network timeouts | Yes | context deadline exceeded during dial |
-| Connection failures | Yes | connection refused, connection reset |
-| PostgreSQL connection errors | Yes | 08000, 08003, 08006 |
-| Server shutdown | Yes | 57P01, 57P02, 57P03 |
-| Serialization/deadlock | Yes | 40001, 40P01 |
-| Context cancellation | No | context canceled |
-| No rows found | No | pgx.ErrNoRows |
-| Constraint violations | No | unique_violation, foreign_key_violation |
-| Syntax errors | No | syntax_error |
-
-```go
-// Check if an error would be retried
-if pgxkit.IsRetryableError(err) {
-    log.Println("Transient error - would retry")
-} else {
-    log.Println("Permanent error - would not retry")
-}
-```
-
-## Health Checks
-
-```go
-// Check database connectivity
-if db.IsReady(ctx) {
-    log.Println("Database is ready")
-}
-
-// Detailed health check
-if err := db.HealthCheck(ctx); err != nil {
-    log.Printf("Database health check failed: %v", err)
-}
-```
+The typed form `pgxkit.Retry[T]` returns a value. The retry budget is the context deadline — all attempts share it.
 
 ## Testing
 
-### Running the Test Suite
-
-This repo uses a `Makefile` as the single entry point for tests, lint, and
-benchmarks — both locally and in CI. Always use the make targets so the two
-stay in sync.
-
 ```bash
-make test-db-up    # start a containerized Postgres on a free host port
-make test          # run the full suite
-make test-db-down  # tear down when done
+make test-db-up    # containerized Postgres on a free port
+make test
+make test-db-down
 ```
 
-Other targets: `make test-coverage`, `make coverage-html`, `make bench`,
-`make lint`, `make help`.
-
-Requires Docker. To use an existing Postgres instead, set `TEST_DATABASE_URL`
-and run `go test ./...` directly.
-
-### Basic Testing
+`make` is the canonical entry point — see the project Makefile for `test-coverage`, `bench`, `lint`, etc.
 
 ```go
-func TestUserOperations(t *testing.T) {
-    testDB := pgxkit.NewTestDB()
-    ctx := context.Background()
-    err := testDB.Connect(ctx, "") // Uses TEST_DATABASE_URL env var
-    if err != nil {
-        t.Skip("Test database not available")
-    }
-    defer testDB.Shutdown(ctx)
-
-    err = testDB.Setup()
-    if err != nil {
-        t.Skip("Test database setup failed")
-    }
-    defer testDB.Clean()
-
-    // Use testDB.DB for your tests
-    _, err = testDB.Exec(ctx, "INSERT INTO users ...")
-    // ... test assertions
+func TestThing(t *testing.T) {
+    testDB := pgxkit.RequireDB(t) // skips when TEST_DATABASE_URL is unset
+    // ... use testDB.DB ...
 }
 ```
 
-### Plan-Regression Testing
+### Plan-regression
+
+`AssertPlan` captures `EXPLAIN (FORMAT JSON, COSTS OFF)` per query and compares to `testdata/plans/<name>.json`. A plan-shape change (index-scan → seq-scan, hash-join → nested-loop, etc.) fails with a unified diff.
 
 ```go
-func TestUserQueries(t *testing.T) {
-    testDB := pgxkit.NewTestDB()
-    ctx := context.Background()
-    err := testDB.Connect(ctx, "")
-    if err != nil {
-        t.Skip("Test database not available")
-    }
-    defer testDB.Shutdown(ctx)
-
-    testDB.Setup()
-    defer testDB.Clean()
-
-    db := testDB.EnableAssertPlan("TestUserQueries")
-
-    rows, err := db.Query(ctx, "SELECT * FROM users WHERE active = true")
-    // ... more queries
-
-    // First run writes testdata/plans/TestUserQueries.json; later runs fail
-    // with a unified diff on plan-shape change. Regenerate with `go test -overwrite-plan`.
-    db.AssertPlan(t, "TestUserQueries")
-}
+db := testDB.EnableAssertPlan("TestUserSummary")
+_, _ = db.Query(ctx, "SELECT ...")
+db.AssertPlan(t, "TestUserSummary")
 ```
 
-### Golden Transcript Testing
+Refresh: `go test -overwrite-plan`.
+
+### Golden transcript
+
+`AssertGolden` records the ordered event stream (`BEGIN`, every `Query`/`Exec` with SQL + normalized args, `rows_affected` for Exec, `COMMIT`/`ROLLBACK`) and compares to `testdata/golden/<name>.json`. Catches an extra UPDATE, missing INSERT, different argument, `COMMIT` becoming `ROLLBACK`.
 
 ```go
-func TestCreateOrder(t *testing.T) {
-    testDB := pgxkit.NewTestDB()
-    ctx := context.Background()
-    err := testDB.Connect(ctx, "")
-    if err != nil {
-        t.Skip("Test database not available")
-    }
-    defer testDB.Shutdown(ctx)
-
-    // Captures BEGIN/QUERY/COMMIT/ROLLBACK events with normalized args and rows.
-    golden := testDB.EnableGolden("TestCreateOrder")
-
-    // ... call the code under test using golden as the DB ...
-
-    // Writes testdata/golden/TestCreateOrder.json on first run; diffs the
-    // transcript on subsequent runs. Use `go test -overwrite-golden` to refresh.
-    golden.AssertGolden(t, "TestCreateOrder")
-}
+golden := testDB.EnableGolden("TestCreateOrder")
+// ... run code under test ...
+golden.AssertGolden(t, "TestCreateOrder")
 ```
 
-## Type Helpers
+Refresh: `go test -overwrite-golden`.
 
-Seamless conversions between Go types and pgx types:
+## Type helpers
+
+Thin converters between Go types and pgx's `pgtype.*`. See the [API reference](../../wiki/API-Reference#type-helpers) for the full list.
 
 ```go
-// String conversions
 pgxText := pgxkit.ToPgxText(&myString)
-stringPtr := pgxkit.FromPgxText(pgxText)
-
-// Numeric conversions
-pgxInt := pgxkit.ToPgxInt8(&myInt64)
-intPtr := pgxkit.FromPgxInt8(pgxInt)
-
-// UUID conversions
+str     := pgxkit.FromPgxText(pgxText)
 pgxUUID := pgxkit.ToPgxUUID(myUUID)
-uuid := pgxkit.FromPgxUUID(pgxUUID)
-
-// Time conversions
-pgxTime := pgxkit.ToPgxTimestamptz(&myTime)
-timePtr := pgxkit.FromPgxTimestamptz(pgxTime)
-
-// Array conversions
-pgxArray := pgxkit.ToPgxTextArray(myStringSlice)
-stringSlice := pgxkit.FromPgxTextArray(pgxArray)
 ```
 
-## Production Features
+## Graceful shutdown
 
-### Graceful Shutdown
+`db.Shutdown(ctx)` waits for active operations (including in-flight transactions started by `BeginTx`), runs `OnShutdown` hooks, then closes the pools.
 
 ```go
-// Graceful shutdown with timeout
+sig := make(chan os.Signal, 1)
+signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+<-sig
 ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 defer cancel()
-
-err := db.Shutdown(ctx)
-if err != nil {
-    log.Printf("Shutdown completed with warnings: %v", err)
-}
+_ = db.Shutdown(ctx)
 ```
 
-### Connection Statistics
+## Code generation
+
+`*pgxkit.DB` implements the same `Query`/`QueryRow`/`Exec` shape generators expect, and `db.WritePool()` / `db.ReadPool()` return `*pgxpool.Pool` for tools that want it directly.
 
 ```go
-// Get pool statistics
-stats := db.Stats()          // Write pool stats
-readStats := db.ReadStats()  // Read pool stats (if using read/write split)
-
-log.Printf("Active connections: %d", stats.AcquiredConns())
-log.Printf("Idle connections: %d", stats.IdleConns())
-```
-
-### Error Handling
-
-```go
-// Structured error types
-err := pgxkit.NewNotFoundError("User", userID)
-err := pgxkit.NewValidationError("Email", "create", "address", "invalid format", nil)
-err := pgxkit.NewDatabaseError("Order", "query", originalErr)
-
-// Type checking
-var notFoundErr *pgxkit.NotFoundError
-if errors.As(err, &notFoundErr) {
-    // Handle not found error
-}
-```
-
-## Architecture
-
-pgxkit follows these design principles:
-
-1. **Safety First** - All default methods use write pool for consistency
-2. **Explicit Optimization** - Use `ReadQuery()` methods for read optimization
-3. **Tool Agnostic** - Works with any PostgreSQL development approach
-4. **Extensible** - Hook system for custom functionality
-5. **Production Ready** - Built-in observability and lifecycle management
-
-## Examples
-
-### With Raw pgx
-
-```go
-db := pgxkit.NewDB()
-db.Connect(ctx, "postgres://...")
-
-// Use pgx directly with pgxkit utilities
-rows, err := db.Query(ctx, "SELECT * FROM users")
-for rows.Next() {
-    var user User
-    err := rows.Scan(&user.ID, &user.Name)
-    // ...
-}
-```
-
-### With Any Code Generation Tool
-
-```go
-// Works with sqlc, Skimatik, or any other tool
-db := pgxkit.NewDB()
-db.Connect(ctx, "postgres://...")
-
-// Use your generated code with pgxkit's connection
-queries := sqlc.New(db.GetPool()) // or your tool's constructor
-users, err := queries.GetAllUsers(ctx)
-```
-
-### With Hooks for Observability
-
-```go
-db := pgxkit.NewDB()
-err := db.Connect(ctx, dsn,
-    // Add tracing
-    pgxkit.WithBeforeOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-        span := trace.SpanFromContext(ctx)
-        span.SetAttributes(attribute.String("db.statement", sql))
-        return nil
-    }),
-    // Add metrics
-    pgxkit.WithAfterOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-        status := "success"
-        if operationErr != nil {
-            status = "error"
-        }
-        queryCounter.WithLabelValues(status).Inc()
-        return nil
-    }),
-)
+queries := sqlc.New(db.WritePool())
 ```
 
 ## Documentation
 
-**[Visit the pgxkit Wiki](../../wiki)** - Complete documentation with examples and guides
+Full docs are in the [wiki](../../wiki):
 
-### Quick Links
-- **[Getting Started](../../wiki/Getting-Started)** - Setup and basic usage
-- **[API Reference](../../wiki/API-Reference)** - Complete API documentation
-- **[Examples](../../wiki/Examples)** - Practical code examples and use cases
-- **[Performance Guide](../../wiki/Performance-Guide)** - Optimization strategies
-- **[Production Guide](../../wiki/Production-Guide)** - Deployment best practices
-- **[Testing Guide](../../wiki/Testing-Guide)** - Testing strategies and plan-regression tests
-- **[FAQ](../../wiki/FAQ)** - Frequently asked questions
-
-## Contributing
-
-We welcome contributions! Please see our **[Contributing Guide](../../wiki/Contributing)** for details.
+- [Getting Started](../../wiki/Getting-Started) · [Examples](../../wiki/Examples)
+- [API Reference](../../wiki/API-Reference)
+- [Performance](../../wiki/Performance-Guide) · [Production](../../wiki/Production-Guide) · [Testing](../../wiki/Testing-Guide)
+- [FAQ](../../wiki/FAQ) · [Contributing](../../wiki/Contributing)
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) file for details.
-
+MIT — see [LICENSE](LICENSE).

--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -446,25 +446,7 @@ const (
 )
 ```
 
-These constants are passed as the `sql` parameter to `AfterTransaction` hooks, allowing you to distinguish between commit and rollback operations.
-
-| Constant | Value | Description |
-|----------|-------|-------------|
-| `TxCommit` | `"TX:COMMIT"` | Passed when a transaction is committed |
-| `TxRollback` | `"TX:ROLLBACK"` | Passed when a transaction is rolled back |
-
-**Example:**
-```go
-pgxkit.WithAfterTransaction(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-    switch sql {
-    case pgxkit.TxCommit:
-        log.Println("Transaction committed")
-    case pgxkit.TxRollback:
-        log.Println("Transaction rolled back")
-    }
-    return nil
-})
-```
+Passed as the `sql` parameter to `AfterTransaction` hooks so handlers can tell commits from rollbacks.
 
 ## Hook System
 
@@ -870,7 +852,7 @@ Compares the in-memory plans captured by `EnableAssertPlan` against `testdata/pl
 func (tdb *TestDB) EnableGolden(testName string, opts ...GoldenOption) *DB
 ```
 
-Enables golden transcript testing. Records every database event (BEGIN, QUERY, COMMIT, ROLLBACK) the scenario produces, along with the SQL, normalized args, and materialized result rows. Call `AssertGolden` after the scenario to compare the transcript against `testdata/golden/<testName>.json`. Volatile values (`time.Time`, UUIDs, integer columns named `id` or `*_id`) are normalized to stable placeholders so transcripts compare cleanly across runs.
+Enables golden transcript testing. Records every database event (BEGIN, QUERY, COMMIT, ROLLBACK) the scenario produces, along with the SQL, normalized args, and `rows_affected` for Exec calls. Call `AssertGolden` to compare the transcript against `testdata/golden/<testName>.json`. Volatile arg values (`time.Time`, UUIDs) are normalized to stable placeholders so transcripts compare cleanly across runs.
 
 **Example:**
 ```go
@@ -893,7 +875,7 @@ Use `go test -overwrite-golden` to regenerate baselines after intentional behavi
 ### GoldenOption / WithGoldenNormalizer
 
 ```go
-type GoldenOption func(*transcriptRecorder)
+type GoldenOption func(*assertGoldenHook)
 
 func WithGoldenNormalizer(fn func(any) (any, bool)) GoldenOption
 ```
@@ -926,33 +908,15 @@ dsn := pgxkit.GetDSN()
 
 ## Error Handling
 
-pgxkit provides PostgreSQL-aware error handling and categorization:
-
-- **Connection errors** - Detected and handled by retry logic
-- **Constraint violations** - Preserved and wrapped for application handling
-- **Timeout errors** - Detected and can trigger circuit breaker logic
-- **Serialization failures** - Automatically retried when using retry logic
+`RetryOperation` and `Retry[T]` classify and retry transient PostgreSQL errors (connection drops, serialization failures, deadlocks). Constraint violations and other deterministic errors are returned to the caller unchanged.
 
 ## Thread Safety
 
-All `DB` methods are thread-safe and can be called concurrently from multiple goroutines. The underlying connection pools handle concurrent access safely.
-
-## Best Practices
-
-1. **Use Read methods for optimization** - `ReadQuery()` and `ReadQueryRow()` when you have read/write splits
-2. **Configure via options** - Pass all configuration (pool settings, hooks) as options to `Connect()`
-3. **Handle context cancellation** - All methods respect context cancellation
-4. **Use transactions for consistency** - Group related operations in transactions
-5. **Monitor pool statistics** - Use `Stats()` and `ReadStats()` for monitoring
-6. **Implement graceful shutdown** - Use `Shutdown()` with appropriate timeout
+All `DB` methods are safe for concurrent use. `*Tx` is not — use one transaction per goroutine.
 
 ## See Also
 
-- **[Getting Started](Getting-Started)** - Basic setup and configuration
-- **[Examples](Examples)** - Practical code examples
-- **[Performance Guide](Performance-Guide)** - Optimization strategies
-- **[Production Guide](Production-Guide)** - Deployment best practices
-- **[Testing Guide](Testing-Guide)** - Testing strategies
+- [Getting Started](Getting-Started) · [Examples](Examples) · [Testing Guide](Testing-Guide)
 
 ---
 

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -1,145 +1,41 @@
-# pgxkit Usage Examples
+# Examples
 
-**[<- Back to Home](Home)**
+**[← Back to Home](Home)**
 
-This document provides comprehensive examples of using pgxkit - the tool-agnostic PostgreSQL toolkit.
+Practical patterns. For installation and a first query, see [Getting Started](Getting-Started).
 
-## Table of Contents
+## Contents
 
-1. [Basic Usage](#basic-usage)
-2. [Read/Write Split](#readwrite-split)
-3. [Executor Interface](#executor-interface)
-4. [Hook System](#hook-system)
-5. [Retry Logic](#retry-logic)
-6. [Health Checks](#health-checks)
-7. [Testing](#testing)
-8. [Type Helpers](#type-helpers)
-9. [Metrics and Observability](#metrics-and-observability)
-10. [Production Patterns](#production-patterns)
-11. [Integration with Code Generation](#integration-with-code-generation)
+1. [Read/write split](#readwrite-split)
+2. [Executor interface](#executor-interface)
+3. [Hooks](#hooks)
+4. [Retry](#retry)
+5. [Health checks](#health-checks)
+6. [Testing](#testing)
+7. [Type helpers](#type-helpers)
+8. [Code generation](#code-generation)
 
-## Basic Usage
-
-### Simple Connection and Queries
-
-```go
-package main
-
-import (
-    "context"
-    "log"
-    "github.com/nhalm/pgxkit"
-)
-
-func main() {
-    ctx := context.Background()
-
-    // Create and connect to database
-    db := pgxkit.NewDB()
-
-    // Connect using environment variables (POSTGRES_* env vars)
-    err := db.Connect(ctx, "")
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer db.Shutdown(ctx)
-
-    // Execute queries (uses write pool by default - safe)
-    _, err = db.Exec(ctx, "INSERT INTO users (name, email) VALUES ($1, $2)",
-        "John Doe", "john@example.com")
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    // Query data
-    rows, err := db.Query(ctx, "SELECT id, name, email FROM users")
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer rows.Close()
-
-    for rows.Next() {
-        var id int
-        var name, email string
-        if err := rows.Scan(&id, &name, &email); err != nil {
-            log.Fatal(err)
-        }
-        log.Printf("User: %d - %s (%s)", id, name, email)
-    }
-}
-```
-
-### With Explicit DSN
+## Read/write split
 
 ```go
 db := pgxkit.NewDB()
-err := db.Connect(ctx, "postgres://user:password@localhost/dbname?sslmode=disable")
-if err != nil {
-    log.Fatal(err)
-}
+_ = db.ConnectReadWrite(ctx,
+    "postgres://user:pass@replica/db",
+    "postgres://user:pass@primary/db",
+)
 defer db.Shutdown(ctx)
+
+// Reads on the replica:
+rows, _ := db.ReadQuery(ctx, "SELECT * FROM users WHERE active = true")
+// Writes on the primary:
+_, _ = db.Exec(ctx, "UPDATE users SET last_login = NOW() WHERE id = $1", id)
 ```
 
-## Read/Write Split
+## Executor interface
 
-### Separate Read and Write Pools
-
-```go
-func main() {
-    ctx := context.Background()
-    db := pgxkit.NewDB()
-
-    // Connect with separate read and write pools
-    err := db.ConnectReadWrite(ctx,
-        "postgres://user:pass@read-replica:5432/db",  // Read pool
-        "postgres://user:pass@primary:5432/db")       // Write pool
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer db.Shutdown(ctx)
-
-    // Use read pool for queries (better performance)
-    rows, err := db.ReadQuery(ctx, "SELECT * FROM users WHERE active = true")
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer rows.Close()
-
-    // Use write pool for modifications
-    _, err = db.Exec(ctx, "UPDATE users SET last_login = NOW() WHERE id = $1", userID)
-    if err != nil {
-        log.Fatal(err)
-    }
-}
-```
-
-### Smart Query Routing
+`*DB` and `*Tx` both implement `Executor`. Write repository functions against the interface and they work in or out of a transaction.
 
 ```go
-// Automatically route queries based on operation type
-func smartQuery(db *pgxkit.DB, sql string, args ...interface{}) (pgx.Rows, error) {
-    if isReadQuery(sql) {
-        return db.ReadQuery(ctx, sql, args...)
-    }
-    return db.Query(ctx, sql, args...)
-}
-
-func isReadQuery(sql string) bool {
-    sql = strings.ToUpper(strings.TrimSpace(sql))
-    return strings.HasPrefix(sql, "SELECT") ||
-           strings.HasPrefix(sql, "WITH") ||
-           strings.HasPrefix(sql, "EXPLAIN")
-}
-```
-
-## Executor Interface
-
-### Writing Reusable Repository Functions
-
-The `Executor` interface allows you to write functions that work with both `*DB` and `*Tx`, making your code reusable across transactional and non-transactional contexts.
-
-```go
-// Repository function that accepts Executor interface
 func CreateUser(ctx context.Context, exec pgxkit.Executor, name, email string) (int64, error) {
     var id int64
     err := exec.QueryRow(ctx,
@@ -148,721 +44,171 @@ func CreateUser(ctx context.Context, exec pgxkit.Executor, name, email string) (
     return id, err
 }
 
-func UpdateUserEmail(ctx context.Context, exec pgxkit.Executor, id int64, email string) error {
-    _, err := exec.Exec(ctx,
-        "UPDATE users SET email = $1 WHERE id = $2",
-        email, id)
-    return err
-}
+// Outside a transaction:
+id, _ := CreateUser(ctx, db, "Alice", "alice@example.com")
 
-func GetUser(ctx context.Context, exec pgxkit.Executor, id int64) (*User, error) {
-    var user User
-    err := exec.QueryRow(ctx,
-        "SELECT id, name, email FROM users WHERE id = $1",
-        id).Scan(&user.ID, &user.Name, &user.Email)
-    if err != nil {
-        return nil, err
-    }
-    return &user, nil
-}
+// Inside a transaction:
+tx, _ := db.BeginTx(ctx, pgx.TxOptions{})
+defer tx.Rollback(ctx)
+id, _ = CreateUser(ctx, tx, "Bob", "bob@example.com")
+_ = tx.Commit(ctx)
 ```
 
-### Using Repository Functions Without Transactions
+## Hooks
+
+`HookFunc` is `func(ctx, sql, args, tag pgconn.CommandTag, err error) error`. `tag` is meaningful for `AfterOperation` on Exec; zero everywhere else.
 
 ```go
-func main() {
-    ctx := context.Background()
-    db := pgxkit.NewDB()
-    err := db.Connect(ctx, "")
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer db.Shutdown(ctx)
-
-    // Use repository functions directly with *DB
-    id, err := CreateUser(ctx, db, "Alice", "alice@example.com")
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    user, err := GetUser(ctx, db, id)
-    if err != nil {
-        log.Fatal(err)
-    }
-    log.Printf("Created user: %+v", user)
-}
+db.Connect(ctx, "",
+    // Log every query.
+    pgxkit.WithBeforeOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, err error) error {
+        slog.InfoContext(ctx, "query", "sql", sql)
+        return nil
+    }),
+    // Count outcomes; tag.RowsAffected() is real for Exec.
+    pgxkit.WithAfterOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, err error) error {
+        if err != nil {
+            metrics.QueryErrors.Inc()
+        } else if tag.String() != "" {
+            metrics.RowsAffected.Add(float64(tag.RowsAffected()))
+        }
+        return nil
+    }),
+    // Distinguish commit vs rollback via the `sql` parameter.
+    pgxkit.WithAfterTransaction(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, err error) error {
+        switch sql {
+        case pgxkit.TxCommit:   metrics.TxCommits.Inc()
+        case pgxkit.TxRollback: metrics.TxRollbacks.Inc()
+        }
+        return nil
+    }),
+)
 ```
 
-### Using Repository Functions Within Transactions
+A before-hook returning a non-nil error aborts the operation. After-hook errors don't change the operation's result but are reported.
+
+## Retry
+
+`RetryOperation` retries on transient PostgreSQL errors (serialization failures, deadlocks, connection drops). For a typed return, use `Retry[T]`.
 
 ```go
-func TransferUserData(ctx context.Context, db *pgxkit.DB, fromID, toID int64) error {
+err := pgxkit.RetryOperation(ctx, func(ctx context.Context) error {
     tx, err := db.BeginTx(ctx, pgx.TxOptions{})
     if err != nil {
         return err
     }
     defer tx.Rollback(ctx)
-
-    // Get source user using the same repository function
-    sourceUser, err := GetUser(ctx, tx, fromID)
-    if err != nil {
-        return fmt.Errorf("failed to get source user: %w", err)
+    if _, err := tx.Exec(ctx, "UPDATE accounts SET balance = balance - $1 WHERE id = $2", amount, fromID); err != nil {
+        return err
     }
-
-    // Update destination user using the same repository function
-    err = UpdateUserEmail(ctx, tx, toID, sourceUser.Email)
-    if err != nil {
-        return fmt.Errorf("failed to update destination user: %w", err)
+    if _, err := tx.Exec(ctx, "UPDATE accounts SET balance = balance + $1 WHERE id = $2", amount, toID); err != nil {
+        return err
     }
-
     return tx.Commit(ctx)
-}
+}, pgxkit.WithMaxRetries(5))
 ```
 
-### Service Layer Pattern
-
 ```go
-type UserService struct {
-    db *pgxkit.DB
-}
-
-func (s *UserService) CreateUserWithProfile(ctx context.Context, name, email, bio string) (*User, error) {
-    tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
-    if err != nil {
-        return nil, err
-    }
-    defer tx.Rollback(ctx)
-
-    // Create user
-    userID, err := CreateUser(ctx, tx, name, email)
-    if err != nil {
-        return nil, fmt.Errorf("failed to create user: %w", err)
-    }
-
-    // Create profile in same transaction
-    _, err = tx.Exec(ctx,
-        "INSERT INTO profiles (user_id, bio) VALUES ($1, $2)",
-        userID, bio)
-    if err != nil {
-        return nil, fmt.Errorf("failed to create profile: %w", err)
-    }
-
-    if err := tx.Commit(ctx); err != nil {
-        return nil, err
-    }
-
-    // Fetch and return the complete user
-    return GetUser(ctx, s.db, userID)
-}
+user, err := pgxkit.Retry(ctx, func(ctx context.Context) (*User, error) {
+    var u User
+    err := db.QueryRow(ctx, "SELECT id, name FROM users WHERE id = $1", id).Scan(&u.ID, &u.Name)
+    return &u, err
+})
 ```
 
-## Hook System
-
-### Logging Hook
+## Health checks
 
 ```go
-func setupLogging() *pgxkit.DB {
-    ctx := context.Background()
-    db := pgxkit.NewDB()
-
-    err := db.Connect(ctx, "",
-        pgxkit.WithBeforeOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-            log.Printf("Executing: %s", sql)
-            return nil
-        }),
-        pgxkit.WithAfterOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-            if operationErr != nil {
-                log.Printf("Query failed: %v", operationErr)
-            } else {
-                log.Printf("Query completed successfully")
-            }
-            return nil
-        }),
-    )
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    return db
-}
-```
-
-### Metrics Hook
-
-```go
-func setupMetrics() *pgxkit.DB {
-    ctx := context.Background()
-    db := pgxkit.NewDB()
-
-    err := db.Connect(ctx, "",
-        pgxkit.WithAfterOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-            operation := extractOperation(sql) // Parse SELECT, INSERT, etc.
-
-            // Record query count
-            if operationErr != nil {
-                metrics.QueryErrors.WithLabelValues(operation).Inc()
-            } else {
-                metrics.QuerySuccess.WithLabelValues(operation).Inc()
-            }
-
-            return nil
-        }),
-    )
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    return db
-}
-```
-
-### Transaction Outcome Hook
-
-```go
-func setupTransactionMetrics() *pgxkit.DB {
-    ctx := context.Background()
-    db := pgxkit.NewDB()
-
-    err := db.Connect(ctx, "",
-        pgxkit.WithAfterTransaction(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-            // The sql parameter indicates transaction outcome
-            switch sql {
-            case pgxkit.TxCommit:
-                if operationErr != nil {
-                    metrics.TransactionCommitErrors.Inc()
-                    log.Printf("Transaction commit failed: %v", operationErr)
-                } else {
-                    metrics.TransactionCommits.Inc()
-                }
-            case pgxkit.TxRollback:
-                if operationErr != nil {
-                    metrics.TransactionRollbackErrors.Inc()
-                    log.Printf("Transaction rollback failed: %v", operationErr)
-                } else {
-                    metrics.TransactionRollbacks.Inc()
-                }
-            }
-            return nil
-        }),
-    )
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    return db
-}
-```
-
-## Retry Logic
-
-### Basic Retry
-
-```go
-func executeWithRetry(db *pgxkit.DB) {
-    // Retry with default settings:
-    // - 3 retry attempts
-    // - 100ms initial delay
-    // - 1s maximum delay
-    // - 2x exponential backoff
-    err := pgxkit.RetryOperation(ctx, func(ctx context.Context) error {
-        _, err := db.Exec(ctx,
-            "INSERT INTO users (name, email) VALUES ($1, $2)",
-            "Jane Doe", "jane@example.com")
-        return err
-    })
-    if err != nil {
-        log.Fatal("Failed after retries:", err)
-    }
-
-    log.Println("User inserted successfully")
-}
-```
-
-### Retry with Custom Configuration
-
-```go
-func executeWithCustomRetry(db *pgxkit.DB) {
-    // Retry with custom settings using functional options
-    err := pgxkit.RetryOperation(ctx, func(ctx context.Context) error {
-        _, err := db.Exec(ctx,
-            "INSERT INTO users (name, email) VALUES ($1, $2)",
-            "Jane Doe", "jane@example.com")
-        return err
-    },
-        pgxkit.WithMaxRetries(5),
-        pgxkit.WithBaseDelay(50*time.Millisecond),
-        pgxkit.WithMaxDelay(2*time.Second),
-    )
-    if err != nil {
-        log.Fatal("Failed after retries:", err)
-    }
-}
-```
-
-### Retry Queries
-
-```go
-func queryWithRetry(db *pgxkit.DB) ([]User, error) {
-    var users []User
-    err := pgxkit.RetryOperation(ctx, func(ctx context.Context) error {
-        rows, err := db.Query(ctx, "SELECT id, name, email FROM users WHERE active = true")
-        if err != nil {
-            return err
-        }
-        defer rows.Close()
-
-        users = nil // Reset on retry
-        for rows.Next() {
-            var user User
-            if err := rows.Scan(&user.ID, &user.Name, &user.Email); err != nil {
-                return err
-            }
-            users = append(users, user)
-        }
-        return rows.Err()
-    }, pgxkit.WithMaxRetries(3))
-
-    return users, err
-}
-```
-
-### Retry Transactions
-
-```go
-func executeTransactionWithRetry(db *pgxkit.DB) error {
-    return pgxkit.RetryOperation(ctx, func(ctx context.Context) error {
-        tx, err := db.BeginTx(ctx, pgx.TxOptions{})
-        if err != nil {
-            return err
-        }
-        defer tx.Rollback(ctx)
-
-        // Perform transaction operations
-        _, err = tx.Exec(ctx, "UPDATE accounts SET balance = balance - $1 WHERE id = $2", amount, fromID)
-        if err != nil {
-            return err
-        }
-
-        _, err = tx.Exec(ctx, "UPDATE accounts SET balance = balance + $1 WHERE id = $2", amount, toID)
-        if err != nil {
-            return err
-        }
-
-        return tx.Commit(ctx)
-    }, pgxkit.WithMaxRetries(5), pgxkit.WithBackoffMultiplier(2.0))
-}
-```
-
-## Health Checks
-
-### Basic Health Check
-
-```go
-func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
-    ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+    ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
     defer cancel()
-
     if err := db.HealthCheck(ctx); err != nil {
-        w.WriteHeader(http.StatusServiceUnavailable)
-        json.NewEncoder(w).Encode(map[string]string{
-            "status": "unhealthy",
-            "error":  err.Error(),
-        })
+        http.Error(w, err.Error(), http.StatusServiceUnavailable)
         return
     }
-
     w.WriteHeader(http.StatusOK)
-    json.NewEncoder(w).Encode(map[string]string{
-        "status": "healthy",
-    })
-}
-```
-
-### Advanced Health Check
-
-```go
-func advancedHealthCheck(db *pgxkit.DB) error {
-    ctx := context.Background()
-
-    // Check basic connectivity
-    if err := db.HealthCheck(ctx); err != nil {
-        return fmt.Errorf("basic health check failed: %w", err)
-    }
-
-    // Check pool statistics
-    stats := db.Stats()
-    if stats.AcquiredConns() >= stats.MaxConns() {
-        return fmt.Errorf("connection pool exhausted: %d/%d",
-            stats.AcquiredConns(), stats.MaxConns())
-    }
-
-    // Test actual query
-    var result int
-    err := db.QueryRow(ctx, "SELECT 1").Scan(&result)
-    if err != nil {
-        return fmt.Errorf("test query failed: %w", err)
-    }
-
-    return nil
-}
+})
 ```
 
 ## Testing
 
-### Plan-Regression Tests
+`RequireDB` connects via `TEST_DATABASE_URL` and skips when it isn't set.
 
-Plan-regression tests capture the structural plan via `EXPLAIN (FORMAT JSON, COSTS OFF)` and assert it is unchanged across runs. They catch shape changes such as seq-scan to index-scan, nested-loop to hash-join, a new sort node, or a different join order. This does not assert anything about query results.
+### Plan-regression
+
+`AssertPlan` captures `EXPLAIN (FORMAT JSON, COSTS OFF)` per query and compares to `testdata/plans/<name>.json`. Catches plan-shape changes; doesn't look at data.
 
 ```go
-func TestUserQueries(t *testing.T) {
-    ctx := context.Background()
+func TestUserSummary_Plan(t *testing.T) {
+    testDB := pgxkit.RequireDB(t)
+    db := testDB.EnableAssertPlan("TestUserSummary")
 
-    // Setup test database
-    testDB := pgxkit.NewTestDB()
-    err := testDB.Connect(ctx, "")  // Uses TEST_DATABASE_URL env var
-    if err != nil {
-        t.Skip("Test database not available")
-    }
-    defer testDB.Shutdown(ctx)
-
-    // Enable plan-regression test support
-    db := testDB.EnableAssertPlan("TestUserQueries")
-
-    // Load test data using your own fixture loading implementation
-    // pgxkit does not provide a built-in fixture loader - use manual SQL or your preferred tool
-    _, err = testDB.Exec(ctx, `
-        INSERT INTO users (id, name, email) VALUES
-        (1, 'John Doe', 'john@example.com'),
-        (2, 'Jane Smith', 'jane@example.com')
-        ON CONFLICT (id) DO NOTHING
-    `)
-    if err != nil {
-        t.Fatal(err)
-    }
-
-    // Execute query - structural EXPLAIN plan will be captured
     rows, err := db.Query(ctx, `
-        SELECT u.id, u.name, COUNT(o.id) as order_count
-        FROM users u
-        LEFT JOIN orders o ON u.id = o.user_id
+        SELECT u.id, u.name, COUNT(o.id)
+        FROM users u LEFT JOIN orders o ON u.id = o.user_id
         GROUP BY u.id, u.name
-        ORDER BY order_count DESC
     `)
     require.NoError(t, err)
-    defer rows.Close()
+    rows.Close()
 
-    var users []User
-    for rows.Next() {
-        var user User
-        var orderCount int
-        err := rows.Scan(&user.ID, &user.Name, &orderCount)
-        require.NoError(t, err)
-        user.OrderCount = orderCount
-        users = append(users, user)
-    }
-
-    // Plan-regression test will assert the structural query plan is unchanged.
-    // Result rows are NOT compared - assert those yourself.
-    require.Len(t, users, 3)
-
-    db.AssertPlan(t, "TestUserQueries")
+    db.AssertPlan(t, "TestUserSummary")
 }
 ```
 
-### Golden Transcript Tests
+Refresh after intentional changes: `go test -overwrite-plan`.
 
-Golden tests capture the ordered sequence of database events a scenario produces (BEGIN, every Query/Exec with normalized args and rows, COMMIT/ROLLBACK) and assert on subsequent runs that nothing changed.
+### Golden transcript
+
+`AssertGolden` records the ordered event stream — `BEGIN`, every `Query`/`Exec` (with SQL + normalized args, plus `rows_affected` for Exec), `COMMIT`/`ROLLBACK` — and compares to `testdata/golden/<name>.json`.
 
 ```go
 func TestCreateOrder(t *testing.T) {
-    ctx := context.Background()
-
-    testDB := pgxkit.NewTestDB()
-    if err := testDB.Connect(ctx, ""); err != nil {
-        t.Skip("Test database not available")
-    }
-    defer testDB.Shutdown(ctx)
-
+    testDB := pgxkit.RequireDB(t)
     golden := testDB.EnableGolden("TestCreateOrder")
 
     tx, err := golden.BeginTx(ctx, pgx.TxOptions{})
     require.NoError(t, err)
-
     var orderID int
-    err = tx.QueryRow(ctx, `
-        INSERT INTO orders (total) VALUES ($1) RETURNING id
-    `, 100).Scan(&orderID)
+    require.NoError(t, tx.QueryRow(ctx,
+        "INSERT INTO orders (total) VALUES ($1) RETURNING id", 100).Scan(&orderID))
+    _, err = tx.Exec(ctx,
+        "INSERT INTO order_items (order_id, sku, qty) VALUES ($1, $2, $3)",
+        orderID, "SKU-1", 2)
     require.NoError(t, err)
-
-    _, err = tx.Exec(ctx, `
-        INSERT INTO order_items (order_id, sku, qty) VALUES ($1, $2, $3)
-    `, orderID, "SKU-1", 2)
-    require.NoError(t, err)
-
     require.NoError(t, tx.Commit(ctx))
 
-    // First run writes testdata/golden/TestCreateOrder.json.
-    // Subsequent runs diff the transcript and fail on any change.
-    // Use `go test -overwrite-golden` to refresh after intentional changes.
     golden.AssertGolden(t, "TestCreateOrder")
 }
 ```
 
-### Test Database Helper
+Refresh: `go test -overwrite-golden`. Custom normalizers via `pgxkit.WithGoldenNormalizer(...)`.
+
+## Type helpers
+
+`pgxkit/types.go` exposes thin converters between Go types and pgx's `pgtype.*` for clean repository code:
 
 ```go
-func setupTestDB(t *testing.T) *pgxkit.DB {
-    // Use test-specific database
-    dsn := os.Getenv("TEST_DATABASE_URL")
-    if dsn == "" {
-        t.Skip("TEST_DATABASE_URL not set")
-    }
-
-    db := pgxkit.NewDB()
-    err := db.Connect(context.Background(), dsn)
-    require.NoError(t, err)
-
-    t.Cleanup(func() {
-        db.Shutdown(context.Background())
-    })
-
-    return db
-}
-```
-
-## Type Helpers
-
-### Clean Architecture Types
-
-```go
-// Domain types
-type User struct {
-    ID    UserID `json:"id"`
-    Name  string `json:"name"`
-    Email string `json:"email"`
-}
-
-type UserID int64
-
-// Repository implementation
-func (r *UserRepository) GetUser(ctx context.Context, id UserID) (*User, error) {
-    var user User
+func (r *Repo) GetUser(ctx context.Context, id int64) (*User, error) {
+    var u User
     err := r.db.ReadQueryRow(ctx,
-        "SELECT id, name, email FROM users WHERE id = $1",
-        int64(id)).Scan(&user.ID, &user.Name, &user.Email)
-
-    if err != nil {
-        return nil, fmt.Errorf("failed to get user: %w", err)
-    }
-
-    return &user, nil
+        "SELECT id, name, email FROM users WHERE id = $1", id,
+    ).Scan(&u.ID, &u.Name, &u.Email)
+    return &u, err
 }
 ```
 
-## Metrics and Observability
+See [API Reference → Type Helpers](API-Reference#type-helpers) for the full list.
 
-### Prometheus Integration
+## Code generation
+
+`*pgxkit.DB` implements the same `Query`/`QueryRow`/`Exec` shape generators expect, and `db.WritePool()` / `db.ReadPool()` return `*pgxpool.Pool` for tools that want the pool directly.
 
 ```go
-import "github.com/prometheus/client_golang/prometheus"
-
-var (
-    queryDuration = prometheus.NewHistogramVec(
-        prometheus.HistogramOpts{
-            Name: "pgxkit_query_duration_seconds",
-            Help: "Query execution duration",
-        },
-        []string{"operation", "status"},
-    )
-)
-
-func setupPrometheusMetrics() *pgxkit.DB {
-    ctx := context.Background()
-    db := pgxkit.NewDB()
-
-    err := db.Connect(ctx, "",
-        pgxkit.WithAfterOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-            if start, ok := ctx.Value("metrics_start").(time.Time); ok {
-                duration := time.Since(start)
-                operation := extractOperation(sql)
-                status := "success"
-                if operationErr != nil {
-                    status = "error"
-                }
-
-                queryDuration.WithLabelValues(operation, status).Observe(duration.Seconds())
-            }
-            return nil
-        }),
-    )
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    return db
-}
+// sqlc, skimatik, etc.
+queries := sqlc.New(db.WritePool())
+readQueries := sqlc.New(db.ReadPool())
 ```
-
-### Structured Logging with slog
-
-```go
-import "log/slog"
-
-func setupStructuredLogging() *pgxkit.DB {
-    ctx := context.Background()
-    logger := slog.Default()
-    db := pgxkit.NewDB()
-
-    err := db.Connect(ctx, "",
-        pgxkit.WithAfterOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-            if operationErr != nil {
-                logger.ErrorContext(ctx, "database query failed",
-                    slog.String("sql", sql),
-                    slog.String("error", operationErr.Error()),
-                )
-            } else {
-                logger.InfoContext(ctx, "database query completed",
-                    slog.String("sql", sql),
-                    slog.Int("args_count", len(args)),
-                )
-            }
-            return nil
-        }),
-    )
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    return db
-}
-```
-
-## Production Patterns
-
-### Graceful Shutdown
-
-```go
-func main() {
-    db := pgxkit.NewDB()
-    err := db.Connect(context.Background(), "")
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    // Setup graceful shutdown
-    c := make(chan os.Signal, 1)
-    signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-
-    go func() {
-        <-c
-        log.Println("Shutting down gracefully...")
-
-        ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-        defer cancel()
-
-        if err := db.Shutdown(ctx); err != nil {
-            log.Printf("Error during shutdown: %v", err)
-        }
-
-        os.Exit(0)
-    }()
-
-    // Your application logic here
-    select {}
-}
-```
-
-### Connection Pool Monitoring
-
-```go
-func monitorConnectionPool(db *pgxkit.DB) {
-    ticker := time.NewTicker(30 * time.Second)
-    go func() {
-        for range ticker.C {
-            stats := db.Stats()
-
-            utilization := float64(stats.AcquiredConns()) / float64(stats.MaxConns())
-
-            slog.Info("connection pool stats",
-                slog.Int32("acquired_conns", stats.AcquiredConns()),
-                slog.Int32("idle_conns", stats.IdleConns()),
-                slog.Int32("max_conns", stats.MaxConns()),
-                slog.Float64("utilization", utilization),
-            )
-
-            // Alert if utilization is high
-            if utilization > 0.8 {
-                slog.Warn("high connection pool utilization",
-                    slog.Float64("utilization", utilization))
-            }
-        }
-    }()
-}
-```
-
-## Integration with Code Generation
-
-### With sqlc
-
-```go
-//go:generate sqlc generate
-
-func main() {
-    // Setup pgxkit
-    db := pgxkit.NewDB()
-    err := db.Connect(ctx, "")
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer db.Shutdown(ctx)
-
-    // Use sqlc with pgxkit's connection
-    queries := sqlc.New(db) // sqlc can use pgxkit.DB directly
-
-    // Or get specific pools
-    writeQueries := sqlc.New(db.WritePool()) // for write operations
-    readQueries := sqlc.New(db.ReadPool())   // for read operations
-
-    // Use your generated queries
-    users, err := queries.GetAllUsers(ctx)
-    if err != nil {
-        log.Fatal(err)
-    }
-}
-```
-
-### With Other Code Generation Tools
-
-```go
-// pgxkit works with any tool that accepts a pgxpool.Pool
-func main() {
-    db := pgxkit.NewDB()
-    err := db.Connect(ctx, "")
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer db.Shutdown(ctx)
-
-    // Use with any code generation tool
-    queries := skimatik.New(db.WritePool())
-    readQueries := skimatik.New(db.ReadPool())
-
-    // Or use pgxkit directly
-    rows, err := db.Query(ctx, "SELECT * FROM users")
-    // ...
-}
-```
-
-## See Also
-
-- **[Getting Started](Getting-Started)** - Basic setup and configuration
-- **[Performance Guide](Performance-Guide)** - Optimization strategies
-- **[Production Guide](Production-Guide)** - Deployment best practices
-- **[Testing Guide](Testing-Guide)** - Testing strategies and plan-regression tests
-- **[API Reference](API-Reference)** - Complete API documentation
 
 ---
 
-**[<- Back to Home](Home)**
-
-*This comprehensive examples document shows how to use all of pgxkit's features in real-world scenarios. The tool-agnostic design makes it easy to integrate with any PostgreSQL development approach while providing production-ready features out of the box.*
+**[← Back to Home](Home)**

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,768 +1,174 @@
-# Frequently Asked Questions
+# FAQ
 
 **[← Back to Home](Home)**
 
-Common questions and answers about pgxkit usage, configuration, and troubleshooting.
+## General
 
-## Table of Contents
+### Why pgxkit instead of pgx directly?
 
-1. [General Questions](#general-questions)
-2. [Setup and Configuration](#setup-and-configuration)
-3. [Performance and Optimization](#performance-and-optimization)
-4. [Testing](#testing)
-5. [Production Deployment](#production-deployment)
-6. [Troubleshooting](#troubleshooting)
-7. [Migration and Integration](#migration-and-integration)
+pgxkit is built on top of pgx and adds: read/write pool split, an extensible hook system, retry helpers, plan-regression testing, golden-transcript testing, graceful shutdown, and small type helpers. Use plain pgx for one-off scripts; reach for pgxkit when you want any of the above.
 
-## General Questions
+### Does pgxkit work with sqlc / skimatik / other code generators?
 
-### What is pgxkit and how is it different from other PostgreSQL libraries?
+Yes — `*pgxkit.DB` satisfies the same `Query`/`QueryRow`/`Exec` shape, and you can also pass `db.WritePool()` / `db.ReadPool()` to anything expecting `*pgxpool.Pool`.
 
-pgxkit is a **tool-agnostic** PostgreSQL toolkit that provides production-ready utilities while working with any PostgreSQL development approach. Unlike ORMs or query builders, pgxkit doesn't dictate how you write your queries - it works with:
-
-- Raw pgx usage
-- Code generation tools (sqlc, Skimatik, etc.)
-- Any existing PostgreSQL workflow
-
-**Key differences:**
-- **Safety first** - Uses write pool by default, explicit read optimization
-- **Extensible hooks** - Add logging, metrics, tracing without changing your queries
-- **Plan-regression testing** - Catches query plan shape changes (e.g. seq-scan to index-scan)
-- **Production features** - Retry logic, graceful shutdown, health checks built-in
-
-### Should I use pgxkit instead of pgx directly?
-
-pgxkit is built **on top of** pgx, not instead of it. You get all the benefits of pgx plus:
-
-- Connection pool abstraction with read/write splitting
-- Hook system for observability
-- Testing utilities including plan-regression tests
-- Retry logic for transient failures
-- Production-ready lifecycle management
-
-If you're building a production application, pgxkit provides valuable utilities. If you're writing a simple script or tool, direct pgx might be sufficient.
-
-### Is pgxkit compatible with code generation tools?
-
-Yes! pgxkit is specifically designed to be tool-agnostic. It works seamlessly with:
-
-- **sqlc** - Use pgxkit.DB directly or get underlying pools
-- **Skimatik** - Pass connection pools to generated code
-- **Custom code generation** - Any tool that accepts pgxpool.Pool
-- **Raw SQL** - Use pgxkit methods directly
-
-**Example with sqlc:**
 ```go
-db := pgxkit.NewDB()
-err := db.Connect(ctx, dsn)
-
-// Use directly with sqlc
-queries := sqlc.New(db)
-
-// Or get specific pools
-writeQueries := sqlc.New(db.WritePool())
-readQueries := sqlc.New(db.ReadPool())
+queries := sqlc.New(db.WritePool())
 ```
 
-## Setup and Configuration
+## Setup
 
-### How do I configure connection pools for my workload?
+### How do I size the connection pool?
 
-Pool sizing depends on your application characteristics:
+A reasonable starting point is `runtime.NumCPU() * 2` for CPU-bound, `* 4` for I/O-bound, and tune from `db.Stats()` under load. Set via DSN:
 
-**For CPU-bound workloads:**
 ```go
-maxConns := runtime.NumCPU() * 2  // 1-2 connections per core
-```
-
-**For I/O-bound workloads:**
-```go
-maxConns := runtime.NumCPU() * 4  // 2-4 connections per core
-```
-
-**Configuration example:**
-```go
-dsn := fmt.Sprintf("%s?pool_max_conns=%d&pool_min_conns=%d",
-    pgxkit.GetDSN(), maxConns, maxConns/4)
-```
-
-Monitor pool utilization and adjust based on your metrics:
-```go
-stats := db.Stats()
-utilization := float64(stats.AcquiredConns()) / float64(stats.MaxConns())
+dsn := fmt.Sprintf("%s?pool_max_conns=20&pool_min_conns=5", pgxkit.GetDSN())
 ```
 
 ### When should I use read/write splitting?
 
-Use read/write splitting when:
+When you have read replicas and your workload is read-heavy. Use `ConnectReadWrite` and call `ReadQuery` / `ReadQueryRow` for reads that can tolerate replica lag. Skip it for write-heavy workloads or when you need read-your-own-writes.
 
-- You have read replicas available
-- Your application is read-heavy (>70% read operations)
-- You want to optimize read performance
-- You have separate read and write database endpoints
+### What environment variables does pgxkit read?
 
-**Don't use it if:**
-- You only have a single database instance
-- Your application is write-heavy
-- You need strong consistency for all reads
+When `dsn == ""`, pgxkit builds a DSN from `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_SSLMODE`. `pgxkit.GetDSN()` returns the same string for tools that need it externally.
 
-**Setup:**
-```go
-err := db.ConnectReadWrite(ctx,
-    "postgres://user:pass@read-replica:5432/db",  // Read pool
-    "postgres://user:pass@primary:5432/db")       // Write pool
-```
-
-### How do I handle environment variables correctly?
-
-pgxkit uses standard PostgreSQL environment variables:
-
-```bash
-# Required
-export POSTGRES_HOST=localhost
-export POSTGRES_USER=myuser
-export POSTGRES_PASSWORD=mypassword
-export POSTGRES_DB=mydb
-
-# Optional (with defaults)
-export POSTGRES_PORT=5432          # default: 5432
-export POSTGRES_SSLMODE=require    # default: disable
-
-# Connection pool settings
-export POSTGRES_MAX_CONNS=20
-export POSTGRES_MIN_CONNS=5
-```
-
-**Using in code:**
-```go
-// Uses environment variables automatically
-err := db.Connect(ctx, "")
-
-// Or build DSN explicitly
-dsn := pgxkit.GetDSN()
-```
-
-## Performance and Optimization
-
-### How do I optimize read performance?
-
-1. **Use read methods when you have read/write splits:**
-```go
-// Instead of db.Query() (uses write pool)
-rows, err := db.ReadQuery(ctx, "SELECT * FROM users")
-row := db.ReadQueryRow(ctx, "SELECT name FROM users WHERE id = $1", id)
-```
-
-2. **Add appropriate database indexes:**
-```sql
-CREATE INDEX CONCURRENTLY idx_users_email ON users(email);
-CREATE INDEX CONCURRENTLY idx_users_active_created ON users(active, created_at DESC);
-```
-
-3. **Use LIMIT for large result sets:**
-```go
-rows, err := db.ReadQuery(ctx, "SELECT * FROM users ORDER BY created_at DESC LIMIT 100")
-```
-
-4. **Implement caching for frequently accessed data** - See [Performance Guide](Performance-Guide) for detailed strategies.
+## Performance
 
 ### How do I monitor performance?
 
-Configure hooks when connecting to add metrics collection:
+Two pgxkit features cover this:
+
+- `db.Stats()` (and `db.ReadStats()`) returns a `*pgxpool.Stat` with pool counters — feed it to your metrics layer.
+- `WithAfterOperation` fires for every `Query`/`Exec`. Track timing in the hook (start a timer in `WithBeforeOperation`, stop it here):
 
 ```go
-db := pgxkit.NewDB()
-err := db.Connect(ctx, "",
-    pgxkit.WithAfterOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-        duration := time.Since(start) // start from context
-
-        // Prometheus metrics
-        queryDuration.WithLabelValues(operation, status).Observe(duration.Seconds())
-        queryTotal.WithLabelValues(operation, status).Inc()
-
-        // Log slow queries
-        if duration > 100*time.Millisecond {
-            log.Printf("Slow query: %s (took %v)", sql, duration)
-        }
-
-        return nil
-    }),
-)
+pgxkit.WithAfterOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, err error) error {
+    metrics.RecordQuery(sql, time.Since(timeFromCtx(ctx)), err)
+    return nil
+})
 ```
 
-Monitor connection pool utilization:
+### How do I do bulk inserts?
+
+`pgx.Batch` for moderate sizes; `tx.CopyFrom` for thousands of rows. Both work through pgxkit's `Tx`:
+
 ```go
-stats := db.Stats()
-utilization := float64(stats.AcquiredConns()) / float64(stats.MaxConns())
-log.Printf("Pool utilization: %.2f%%", utilization*100)
-```
-
-### What's the best way to handle bulk operations?
-
-Use batch operations for better performance:
-
-**For moderate batch sizes (< 1000 records):**
-```go
-batch := &pgx.Batch{}
-for _, user := range users {
-    batch.Queue("INSERT INTO users (name, email) VALUES ($1, $2)", user.Name, user.Email)
-}
-
-results := tx.SendBatch(ctx, batch)
-defer results.Close()
-```
-
-**For large datasets (1000+ records):**
-```go
-_, err := tx.CopyFrom(ctx,
+tx, _ := db.BeginTx(ctx, pgx.TxOptions{})
+defer tx.Rollback(ctx)
+_, err := tx.Tx().CopyFrom(ctx,
     pgx.Identifier{"users"},
     []string{"name", "email"},
-    pgx.CopyFromSlice(len(users), func(i int) ([]interface{}, error) {
-        return []interface{}{users[i].Name, users[i].Email}, nil
+    pgx.CopyFromSlice(len(users), func(i int) ([]any, error) {
+        return []any{users[i].Name, users[i].Email}, nil
     }),
 )
 ```
 
 ## Testing
 
-### How do I set up tests with pgxkit?
-
-Use the testing utilities for clean test setup:
+### How do I set up a test database?
 
 ```go
-func TestUserRepository(t *testing.T) {
-    // Setup test database
-    suite := NewTestSuite(t)
-    repo := NewUserRepository(suite.DB)
-
-    // Load test data using manual SQL (pgxkit does not provide built-in fixture loading)
-    _, err := suite.DB.Exec(suite.ctx, `
-        INSERT INTO users (id, name, email, active) VALUES
-        (1, 'John Doe', 'john@example.com', true),
-        (2, 'Jane Smith', 'jane@example.com', true)
-        ON CONFLICT (id) DO NOTHING
-    `)
-    require.NoError(t, err)
-
-    // Run your tests
-    users, err := repo.GetActiveUsers(suite.ctx)
-    require.NoError(t, err)
-    assert.Len(t, users, 2)
-}
-
-type TestSuite struct {
-    DB  *pgxkit.TestDB
-    ctx context.Context
-}
-
-func NewTestSuite(t *testing.T) *TestSuite {
-    return &TestSuite{
-        DB:  setupTestDB(t),
-        ctx: context.Background(),
-    }
+func TestThing(t *testing.T) {
+    testDB := pgxkit.RequireDB(t) // skips when TEST_DATABASE_URL is unset
+    // ... use testDB.DB ...
 }
 ```
 
-### What is plan-regression testing and when should I use it?
+`RequireDB` connects via `TEST_DATABASE_URL` and returns a `*TestDB` (which embeds `*DB`).
 
-Plan-regression testing captures the structural query plan via `EXPLAIN (FORMAT JSON, COSTS OFF)` and asserts it is unchanged across runs. It catches plan shape changes that often correlate with performance regressions: a seq-scan replacing an index-scan, a nested-loop turning into a hash-join, a new sort node appearing, or a different join order. It does NOT compare query result rows — assert those yourself in the test body.
+### When should I use Plan-Regression vs Golden testing?
 
-```go
-func TestComplexQuery_Plan(t *testing.T) {
-    testDB := setupTestDB(t)
-    db := testDB.EnableAssertPlan("TestComplexQuery")
+They answer different questions:
 
-    // Structural query plan will be captured and asserted
-    rows, err := db.Query(ctx, `
-        SELECT u.id, u.name, COUNT(o.id) as order_count
-        FROM users u
-        LEFT JOIN orders o ON u.id = o.user_id
-        GROUP BY u.id, u.name
-        ORDER BY order_count DESC
-    `)
-    require.NoError(t, err)
-    defer rows.Close()
+- **`AssertPlan`** — asserts the structural query plan (`EXPLAIN (FORMAT JSON, COSTS OFF)`). Catches a seq-scan replacing an index-scan, a different join order, an extra sort, etc. Doesn't look at data.
+- **`AssertGolden`** — asserts the ordered sequence of database events (`BEGIN`, every `Query`/`Exec` with SQL + normalized args, `rows_affected` for Exec, `COMMIT`/`ROLLBACK`). Catches an extra UPDATE, missing INSERT, different argument, or `COMMIT` that became `ROLLBACK`.
 
-    db.AssertPlan(t, "TestComplexQuery")
-}
-```
-
-**Use plan-regression tests for:**
-- Critical SELECT queries whose plan shape must remain stable
-- Complex queries with multiple joins
-- INSERT/UPDATE/DELETE operations with complex WHERE clauses
-- Queries that depend on specific index usage
-- Catching unintentional plan changes in CI/CD
-
-### When should I use Golden testing vs Plan-Regression testing?
-
-They answer different questions, and pgxkit ships both.
-
-**Plan-Regression (`EnableAssertPlan` / `AssertPlan`)** asserts the *structural query plan* — the shape returned by `EXPLAIN (FORMAT JSON, COSTS OFF)`. It catches plan changes such as a seq-scan replacing an index-scan, a nested-loop turning into a hash-join, or a different join order. It does not look at result rows.
-
-**Golden transcripts (`EnableGolden` / `AssertGolden`)** assert the *behavior* of a scenario — the ordered sequence of `BEGIN`, every `Query`/`Exec` (with SQL, normalized args, and materialized rows), and the closing `COMMIT` or `ROLLBACK`. It catches an extra UPDATE, a missing INSERT, a different argument, a different returned row, or a `COMMIT` that became a `ROLLBACK`.
+Pick one per scenario — `EnableAssertPlan` and `EnableGolden` each return a fresh `*DB` and don't compose.
 
 ```go
-func TestCreateOrder(t *testing.T) {
-    testDB := pgxkit.RequireDB(t)
-
-    golden := testDB.EnableGolden("TestCreateOrder")
-    // ... run the code under test using golden as the DB ...
-    golden.AssertGolden(t, "TestCreateOrder")
-}
+golden := testDB.EnableGolden("TestCreateOrder")
+// ... run code under test ...
+golden.AssertGolden(t, "TestCreateOrder")
 ```
 
-Volatile values (timestamps, UUIDs, sequence-style IDs) are normalized to placeholders so transcripts compare cleanly across runs. Use `go test -overwrite-golden` to refresh the baseline after intentional behavior changes.
+Refresh either baseline with `go test -overwrite-plan` or `-overwrite-golden`.
 
-`EnableGolden` and `EnableAssertPlan` each return a fresh `*DB`, so they don't compose on a single instance — pick one per scenario depending on whether you need plan stability or behavioral stability.
-
-### How do I test error conditions?
-
-Test various error scenarios to ensure robust error handling:
+### How do I test for `pgx.ErrNoRows` / constraint violations?
 
 ```go
-func TestRepository_ErrorHandling(t *testing.T) {
-    suite := NewTestSuite(t)
-    repo := NewUserRepository(suite.DB)
-
-    t.Run("duplicate_email", func(t *testing.T) {
-        // Create user with duplicate email
-        user1 := &User{Email: "test@example.com"}
-        user2 := &User{Email: "test@example.com"}
-
-        err := repo.CreateUser(suite.ctx, user1)
-        require.NoError(t, err)
-
-        err = repo.CreateUser(suite.ctx, user2)
-        assert.Error(t, err)
-        assert.Contains(t, err.Error(), "duplicate")
-    })
-
-    t.Run("not_found", func(t *testing.T) {
-        _, err := repo.GetUser(suite.ctx, 999)
-        assert.Error(t, err)
-        assert.True(t, errors.Is(err, pgx.ErrNoRows))
-    })
-}
+_, err := repo.GetUser(ctx, 999)
+if !errors.Is(err, pgx.ErrNoRows) { /* fail */ }
 ```
 
-## Production Deployment
+For constraint violations, use `errors.As` with `*pgconn.PgError` and check `.Code` (e.g. `"23505"` for unique).
+
+## Production
 
 ### How do I implement graceful shutdown?
 
-Use pgxkit's built-in graceful shutdown:
+`db.Shutdown(ctx)` waits for active operations and runs `OnShutdown` hooks. Wire it to `SIGTERM`:
 
 ```go
-func main() {
-    db := pgxkit.NewDB()
-    err := db.Connect(ctx, "")
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    // Setup graceful shutdown
-    c := make(chan os.Signal, 1)
-    signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-
-    go func() {
-        <-c
-        log.Println("Shutting down...")
-
-        // Give operations time to complete
-        ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-        defer cancel()
-
-        if err := db.Shutdown(ctx); err != nil {
-            log.Printf("Shutdown error: %v", err)
-        }
-
-        os.Exit(0)
-    }()
-
-    // Your application logic here
-}
+sig := make(chan os.Signal, 1)
+signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+<-sig
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+_ = db.Shutdown(ctx)
 ```
 
-### How do I handle database migrations?
+### How do I handle migrations?
 
-pgxkit doesn't include migration tools - use your preferred migration solution:
+pgxkit doesn't ship a migration tool. Use `golang-migrate`, `goose`, or whatever you already use. `pgxkit.GetDSN()` gives you the connection string.
 
-**With golang-migrate:**
-```go
-import "github.com/golang-migrate/migrate/v4"
+### How do I expose a health endpoint?
 
-func runMigrations() error {
-    m, err := migrate.New(
-        "file://migrations",
-        pgxkit.GetDSN())
-    if err != nil {
-        return err
-    }
-
-    return m.Up()
-}
-```
-
-**With custom migrations:**
-```go
-func applyMigrations(db *pgxkit.DB) error {
-    migrations := []string{
-        "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT)",
-        "ALTER TABLE users ADD COLUMN email TEXT",
-    }
-
-    for _, migration := range migrations {
-        _, err := db.Exec(ctx, migration)
-        if err != nil {
-            return err
-        }
-    }
-    return nil
-}
-```
-
-### How do I set up health checks?
-
-Implement health check endpoints for monitoring:
-
-```go
-func healthCheckHandler(db *pgxkit.DB) http.HandlerFunc {
-    return func(w http.ResponseWriter, r *http.Request) {
-        ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
-        defer cancel()
-
-        if err := db.HealthCheck(ctx); err != nil {
-            w.WriteHeader(http.StatusServiceUnavailable)
-            json.NewEncoder(w).Encode(map[string]string{
-                "status": "unhealthy",
-                "error":  err.Error(),
-            })
-            return
-        }
-
-        w.WriteHeader(http.StatusOK)
-        json.NewEncoder(w).Encode(map[string]string{
-            "status": "healthy",
-        })
-    }
-}
-```
+`db.HealthCheck(ctx)` pings the write pool. Wrap it in your HTTP handler — return `503` on error, `200` otherwise.
 
 ## Troubleshooting
 
-### Connection pool exhausted - what should I do?
+### Connection pool exhausted
 
-**Symptoms:**
-- High latency
-- Connection timeouts
-- "failed to get connection" errors
+Check `db.Stats().AcquiredConns()` vs `MaxConns()`. The two common causes:
 
-**Diagnosis:**
-```go
-stats := db.Stats()
-utilization := float64(stats.AcquiredConns()) / float64(stats.MaxConns())
-log.Printf("Pool utilization: %.2f%%", utilization*100)
+- Forgotten `rows.Close()` — every `Query` must be closed even on error.
+- Long-running queries — add `context.WithTimeout` to bound them.
 
-if utilization > 0.8 {
-    log.Println("Pool utilization is high")
-}
-```
+If you really need more capacity and the database can serve it, raise `pool_max_conns` in the DSN.
 
-**Solutions:**
-1. **Increase pool size** (if you have database capacity):
-```go
-dsn := fmt.Sprintf("%s?pool_max_conns=50", pgxkit.GetDSN())
-```
+### My queries are slow
 
-2. **Fix connection leaks** - ensure you're closing rows and statements:
-```go
-rows, err := db.Query(ctx, sql)
-if err != nil {
-    return err
-}
-defer rows.Close() // Always close rows!
-```
+Two complementary moves:
 
-3. **Optimize slow queries** - they hold connections longer
-4. **Implement connection timeouts**:
-```go
-ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-defer cancel()
-```
-
-### My queries are slow - how do I debug them?
-
-1. **Enable query logging:**
-```go
-db := pgxkit.NewDB()
-err := db.Connect(ctx, "",
-    pgxkit.WithAfterOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-        if duration := getDuration(ctx); duration > 100*time.Millisecond {
-            log.Printf("Slow query: %s (took %v)", sql, duration)
-        }
-        return nil
-    }),
-)
-```
-
-2. **Use EXPLAIN ANALYZE:**
-```go
-func analyzeQuery(db *pgxkit.DB, sql string, args ...interface{}) {
-    explainSQL := "EXPLAIN (ANALYZE, BUFFERS) " + sql
-    rows, err := db.Query(ctx, explainSQL, args...)
-    if err != nil {
-        log.Printf("Failed to explain query: %v", err)
-        return
-    }
-    defer rows.Close()
-
-    for rows.Next() {
-        var line string
-        rows.Scan(&line)
-        log.Println(line)
-    }
-}
-```
-
-3. **Check for missing indexes:**
-- Look for "Seq Scan" in query plans
-- Add indexes for frequently queried columns
-- Use partial indexes for filtered queries
+1. **Catch regressions in CI** with `EnableAssertPlan` / `AssertPlan`. Baselines live in `testdata/plans/<test>.json`; a plan flip (index-scan → seq-scan, hash-join → nested-loop) fails the test with a unified diff.
+2. **Investigate ad-hoc** with `EXPLAIN (ANALYZE, BUFFERS) <your query>` against the database directly — pgxkit doesn't wrap this; `psql` is the right tool.
 
 ### SSL connection issues
 
-**Common SSL problems and solutions:**
+Set `POSTGRES_SSLMODE` (`disable` / `prefer` / `require` / `verify-full`). For client certs, append `sslcert=`, `sslkey=`, `sslrootcert=` to the DSN.
 
-1. **SSL required but not configured:**
-```bash
-# Set SSL mode in environment
-export POSTGRES_SSLMODE=require
-```
+### High memory usage
 
-2. **Certificate verification issues:**
-```bash
-# For development (not production!)
-export POSTGRES_SSLMODE=prefer
-```
+Almost always one of: large unbounded result sets (add `LIMIT` or stream with `for rows.Next()`), connection leaks (forgotten `rows.Close()`), or pool sized too high. `db.Stats()` and PostgreSQL's `pg_stat_activity` will tell you which.
 
-3. **Custom certificates:**
-```go
-dsn := fmt.Sprintf(
-    "postgres://user:pass@host/db?sslmode=require&sslcert=%s&sslkey=%s&sslrootcert=%s",
-    certFile, keyFile, rootCertFile)
-```
+## Migrating from `database/sql`
 
-4. **Verify SSL is working:**
-```go
-var sslInUse bool
-err := db.QueryRow(ctx, "SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()").Scan(&sslInUse)
-if err != nil || !sslInUse {
-    log.Println("WARNING: SSL not in use")
-}
-```
-
-### Memory usage is high
-
-**Potential causes and solutions:**
-
-1. **Large result sets** - use LIMIT and pagination:
-```go
-rows, err := db.ReadQuery(ctx, "SELECT * FROM large_table ORDER BY id LIMIT 1000 OFFSET $1", offset)
-```
-
-2. **Connection leaks** - monitor pool statistics:
-```go
-go func() {
-    ticker := time.NewTicker(30 * time.Second)
-    for range ticker.C {
-        stats := db.Stats()
-        log.Printf("Active connections: %d/%d", stats.AcquiredConns(), stats.MaxConns())
-    }
-}()
-```
-
-3. **Result set streaming** for large datasets:
-```go
-func processLargeDataset(db *pgxkit.DB, processor func(*Record) error) error {
-    rows, err := db.ReadQuery(ctx, "SELECT * FROM large_table ORDER BY id")
-    if err != nil {
-        return err
-    }
-    defer rows.Close()
-
-    for rows.Next() {
-        var record Record
-        if err := rows.Scan(&record.ID, &record.Data); err != nil {
-            return err
-        }
-
-        // Process immediately, don't accumulate in memory
-        if err := processor(&record); err != nil {
-            return err
-        }
-    }
-    return rows.Err()
-}
-```
-
-## Migration and Integration
-
-### How do I migrate from database/sql?
-
-1. **Replace sql.DB with pgxkit.DB:**
 ```go
 // Before
-db, err := sql.Open("postgres", dsn)
+db, _ := sql.Open("postgres", dsn)
+rows, _ := db.Query("SELECT * FROM users")
 
-// After
+// After — pgxkit methods take a context
 db := pgxkit.NewDB()
-err := db.Connect(ctx, dsn)
+_ = db.Connect(ctx, dsn)
+rows, _ := db.Query(ctx, "SELECT * FROM users")
 ```
 
-2. **Update query methods:**
-```go
-// Before
-rows, err := db.Query("SELECT * FROM users")
-
-// After
-rows, err := db.Query(ctx, "SELECT * FROM users")
-```
-
-3. **Add context to all operations:**
-```go
-// All pgxkit methods require context
-ctx := context.Background()
-rows, err := db.Query(ctx, "SELECT * FROM users")
-```
-
-4. **Update scanning (pgx uses different types):**
-```go
-// May need to adjust for pgx types
-var id int64  // instead of int
-var name string
-err := rows.Scan(&id, &name)
-```
-
-### How do I integrate with existing code generation?
-
-**With sqlc:**
-```go
-// In your sqlc yaml config, use pgxkit
-gen:
-  go:
-    package: "myapp"
-    out: "db"
-    sql_package: "pgx/v5"
-
-// In your code
-db := pgxkit.NewDB()
-err := db.Connect(ctx, dsn)
-
-queries := myapp.New(db)  // sqlc generated code
-```
-
-**With existing repositories:**
-```go
-type UserRepository struct {
-    db *pgxkit.DB  // Replace your existing db field
-}
-
-func NewUserRepository(db *pgxkit.DB) *UserRepository {
-    return &UserRepository{db: db}
-}
-
-func (r *UserRepository) GetUser(ctx context.Context, id int) (*User, error) {
-    var user User
-    err := r.db.ReadQueryRow(ctx, "SELECT id, name FROM users WHERE id = $1", id).
-        Scan(&user.ID, &user.Name)
-    return &user, err
-}
-```
-
-### Can I use pgxkit with ORMs?
-
-pgxkit is designed to complement raw SQL approaches rather than ORMs. However, you can use it alongside ORMs:
-
-```go
-// Use pgxkit for performance-critical queries
-criticalData, err := pgxkitDB.ReadQuery(ctx, complexOptimizedQuery)
-
-// Use ORM for simpler operations
-user := User{Name: "John"}
-ormDB.Create(&user)
-```
-
-## Common Patterns
-
-### Request-scoped database operations
-
-```go
-func getUserHandler(db *pgxkit.DB) http.HandlerFunc {
-    return func(w http.ResponseWriter, r *http.Request) {
-        // Use request context for cancellation
-        ctx := r.Context()
-
-        userID, _ := strconv.Atoi(r.URL.Query().Get("id"))
-
-        var user User
-        err := db.ReadQueryRow(ctx, "SELECT id, name FROM users WHERE id = $1", userID).
-            Scan(&user.ID, &user.Name)
-        if err != nil {
-            http.Error(w, "User not found", http.StatusNotFound)
-            return
-        }
-
-        json.NewEncoder(w).Encode(user)
-    }
-}
-```
-
-### Background job processing
-
-```go
-func processJobs(db *pgxkit.DB) {
-    ticker := time.NewTicker(10 * time.Second)
-    defer ticker.Stop()
-
-    for range ticker.C {
-        ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-
-        rows, err := db.Query(ctx, "SELECT id, data FROM jobs WHERE status = 'pending' LIMIT 10")
-        if err != nil {
-            log.Printf("Failed to fetch jobs: %v", err)
-            cancel()
-            continue
-        }
-
-        for rows.Next() {
-            var job Job
-            if err := rows.Scan(&job.ID, &job.Data); err != nil {
-                log.Printf("Failed to scan job: %v", err)
-                continue
-            }
-
-            go processJob(db, job)  // Process asynchronously
-        }
-
-        rows.Close()
-        cancel()
-    }
-}
-```
-
-## See Also
-
-- **[Getting Started](Getting-Started)** - Basic setup and usage
-- **[Examples](Examples)** - Practical code examples
-- **[Performance Guide](Performance-Guide)** - Optimization strategies
-- **[Production Guide](Production-Guide)** - Deployment best practices
-- **[Testing Guide](Testing-Guide)** - Testing strategies
-- **[API Reference](API-Reference)** - Complete API documentation
-- **[Contributing](Contributing)** - How to contribute
+pgx has stricter type handling than `database/sql`; expect to scan into `int64` instead of `int` and use `pgtype` for nullable columns. The [pgx wiki](https://github.com/jackc/pgx/wiki) covers the differences.
 
 ---
 
 **[← Back to Home](Home)**
-
-*If you have a question that's not covered here, please [open an issue](https://github.com/nhalm/pgxkit/issues) or start a [discussion](https://github.com/nhalm/pgxkit/discussions).*
-

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -1,48 +1,18 @@
-# Getting Started with pgxkit
+# Getting Started
 
 **[← Back to Home](Home)**
 
-Get up and running with pgxkit in under 5 minutes.
-
-## Table of Contents
-- [Prerequisites](#prerequisites)
-- [Step 1: Install pgxkit](#step-1-install-pgxkit)
-- [Step 2: Set Environment Variables](#step-2-set-environment-variables)
-- [Step 3: Create Your First App](#step-3-create-your-first-app)
-- [Step 4: Run Your App](#step-4-run-your-app)
-- [Step 5: Add Production Features](#step-5-add-production-features)
-- [What's Next?](#whats-next)
-- [Troubleshooting](#troubleshooting)
-
-## Prerequisites
-
-- Go 1.21 or later
-- PostgreSQL 12 or later
-- Basic familiarity with Go and PostgreSQL
-
-## Step 1: Install pgxkit
+## Install
 
 ```bash
-go mod init your-app
-go get github.com/nhalm/pgxkit
+go get github.com/nhalm/pgxkit/v2
 ```
 
-## Step 2: Set Environment Variables
+Requires Go 1.25+ and PostgreSQL 12+.
 
-Set these environment variables (or use a `.env` file):
+## Connect
 
-```bash
-export POSTGRES_HOST=localhost
-export POSTGRES_PORT=5432
-export POSTGRES_USER=postgres
-export POSTGRES_PASSWORD=yourpassword
-export POSTGRES_DB=yourdb
-export POSTGRES_SSLMODE=disable
-```
-
-## Step 3: Create Your First App
-
-Create `main.go`:
+`Connect` accepts a DSN. If empty, it builds one from `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_SSLMODE`.
 
 ```go
 package main
@@ -51,183 +21,68 @@ import (
     "context"
     "log"
 
-    "github.com/nhalm/pgxkit"
+    "github.com/nhalm/pgxkit/v2"
 )
 
 func main() {
     ctx := context.Background()
-
-    // Create and connect to database
     db := pgxkit.NewDB()
-    err := db.Connect(ctx, "") // Uses environment variables
-    if err != nil {
-        log.Fatal("Failed to connect:", err)
+    if err := db.Connect(ctx, ""); err != nil {
+        log.Fatal(err)
     }
     defer db.Shutdown(ctx)
 
-    // Test the connection
     if err := db.HealthCheck(ctx); err != nil {
-        log.Fatal("Database health check failed:", err)
+        log.Fatal(err)
     }
 
-    log.Println("Connected to PostgreSQL!")
-
-    // Create a simple table
-    _, err = db.Exec(ctx, `
-        CREATE TABLE IF NOT EXISTS users (
-            id SERIAL PRIMARY KEY,
-            name TEXT NOT NULL,
-            email TEXT UNIQUE NOT NULL,
-            created_at TIMESTAMP DEFAULT NOW()
-        )
-    `)
-    if err != nil {
-        log.Fatal("Failed to create table:", err)
+    var n int
+    if err := db.QueryRow(ctx, "SELECT 1").Scan(&n); err != nil {
+        log.Fatal(err)
     }
-
-    // Insert a user
-    _, err = db.Exec(ctx,
-        "INSERT INTO users (name, email) VALUES ($1, $2)",
-        "John Doe", "john@example.com")
-    if err != nil {
-        log.Fatal("Failed to insert user:", err)
-    }
-
-    // Query users
-    rows, err := db.Query(ctx, "SELECT id, name, email FROM users")
-    if err != nil {
-        log.Fatal("Failed to query users:", err)
-    }
-    defer rows.Close()
-
-    log.Println("Users:")
-    for rows.Next() {
-        var id int
-        var name, email string
-        if err := rows.Scan(&id, &name, &email); err != nil {
-            log.Fatal("Failed to scan row:", err)
-        }
-        log.Printf("  %d: %s (%s)", id, name, email)
-    }
-
-    log.Println("Success! pgxkit is working.")
+    log.Println("ok:", n)
 }
 ```
 
-## Step 4: Run Your App
+`db.Query`, `db.QueryRow`, `db.Exec` go through the write pool. `db.ReadQuery` and `db.ReadQueryRow` go through the read pool when you've configured one via `ConnectReadWrite`; otherwise they share the single pool.
 
-```bash
-go run main.go
-```
-
-You should see:
-```
-Connected to PostgreSQL!
-Users:
-  1: John Doe (john@example.com)
-Success! pgxkit is working.
-```
-
-## Step 5: Add Production Features
-
-### Add Logging Hook
+## Read/write split
 
 ```go
-// Configure hooks when connecting
-db := pgxkit.NewDB()
-err := db.Connect(ctx, "",
-    pgxkit.WithBeforeOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-        log.Printf("Executing: %s", sql)
+err := db.ConnectReadWrite(ctx,
+    "postgres://user:pass@replica/db",
+    "postgres://user:pass@primary/db")
+```
+
+## Hooks
+
+Every operation passes through configurable hooks. `AfterOperation` receives the `pgconn.CommandTag` from Exec.
+
+```go
+db.Connect(ctx, "",
+    pgxkit.WithBeforeOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, err error) error {
+        log.Printf("query: %s", sql)
         return nil
     }),
 )
 ```
 
-### Add Read/Write Splitting
+See [Examples](Examples#hook-system) for metrics, slog, and transaction-outcome patterns.
+
+## Retry
 
 ```go
-// Instead of db.Connect(), use:
-err := db.ConnectReadWrite(ctx,
-    "postgres://user:pass@read-replica/db",   // Read pool
-    "postgres://user:pass@primary/db")       // Write pool
-
-// Use read pool for queries
-rows, err := db.ReadQuery(ctx, "SELECT * FROM users")
-```
-
-### Add Retry Logic
-
-```go
-// Retry with defaults (3 attempts, 100ms base delay, 1s max delay, 2x backoff)
 err := pgxkit.RetryOperation(ctx, func(ctx context.Context) error {
-    _, err := db.Exec(ctx,
-        "INSERT INTO users (name, email) VALUES ($1, $2)",
-        "Jane Doe", "jane@example.com")
+    _, err := db.Exec(ctx, "INSERT INTO users (name) VALUES ($1)", "Jane")
     return err
 })
-
-// Or with custom retry configuration
-err = pgxkit.RetryOperation(ctx, func(ctx context.Context) error {
-    _, err := db.Exec(ctx, "INSERT INTO users ...")
-    return err
-}, pgxkit.WithMaxRetries(5), pgxkit.WithBaseDelay(200*time.Millisecond))
 ```
 
-## What's Next?
+`RetryOperation` retries on transient PostgreSQL errors (serialization failures, deadlocks, connection issues). Tune via `WithMaxRetries`, `WithBaseDelay`, etc.
 
-**Production Ready**: Your app now has:
-- Connection pooling
-- Health checks
-- Graceful shutdown
-- Hook system for observability
+## Next
 
-**Learn More**:
-- **[Examples](Examples)** - Comprehensive usage examples
-- **[Performance Guide](Performance-Guide)** - Optimization strategies
-- **[Production Guide](Production-Guide)** - Deployment best practices
-- **[Testing Guide](Testing-Guide)** - Plan-regression test support
-
-**Common Patterns**:
-- **[API Reference](API-Reference)** - Complete API documentation
-- **[FAQ](FAQ)** - Common questions and solutions
-
-## Troubleshooting
-
-### Connection Issues
-```bash
-# Test your connection string
-psql "postgres://user:pass@host:port/db"
-```
-
-### Environment Variables
-```bash
-# Check your environment
-env | grep POSTGRES_
-```
-
-### Health Check
-```go
-if err := db.HealthCheck(ctx); err != nil {
-    log.Printf("Health check failed: %v", err)
-}
-```
-
-### Common Solutions
-
-| Issue | Solution |
-|-------|----------|
-| Connection timeout | Check firewall and network connectivity |
-| Authentication failed | Verify username/password and database permissions |
-| Database not found | Ensure database exists and name is correct |
-| SSL errors | Check `POSTGRES_SSLMODE` setting |
-
-## See Also
-
-- **[Examples](Examples)** - More comprehensive examples
-- **[Performance Guide](Performance-Guide)** - Optimize your application
-- **[Production Guide](Production-Guide)** - Deploy to production
-- **[Contributing](Contributing)** - Help improve pgxkit
-
----
-
-**[← Back to Home](Home)**
+- [Examples](Examples) — hooks, retry, testing, type helpers
+- [Testing Guide](Testing-Guide) — `EnableAssertPlan`, `EnableGolden`, `RequireDB`
+- [API Reference](API-Reference)
+- [FAQ](FAQ)

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,34 +1,28 @@
-# Welcome to pgxkit Wiki
+# pgxkit
 
-**pgxkit** is a lightweight, type-safe PostgreSQL toolkit for Go applications that provides a clean abstraction over pgx while maintaining performance and flexibility.
+A focused PostgreSQL toolkit for Go, built on `pgx`. pgxkit gives you a connection pool with read/write split, a hook system, retry helpers, plan-regression and golden-transcript testing, and graceful shutdown — and stays out of your way otherwise.
 
-## Quick Navigation
+## Documentation
 
-### Documentation
-- [Getting Started](Getting-Started) - Setup and basic usage
-- [API Reference](API-Reference) - Complete API documentation
-- [Examples](Examples) - Practical code examples and use cases
+- [Getting Started](Getting-Started) — install, connect, first queries
+- [Examples](Examples) — real patterns for hooks, retries, testing
+- [API Reference](API-Reference) — every public type and function
+- [Performance](Performance-Guide) — pool sizing, plan-regression, monitoring with `db.Stats()`
+- [Production](Production-Guide) — graceful shutdown, health checks, observability hooks
+- [Testing](Testing-Guide) — `RequireDB`, `EnableAssertPlan`, `EnableGolden`
+- [FAQ](FAQ) — quick answers
+- [Contributing](Contributing)
 
-### Performance & Production
-- [Performance Guide](Performance-Guide) - Optimization strategies and best practices
-- [Production Guide](Production-Guide) - Deployment and production considerations
-- [Testing Guide](Testing-Guide) - Testing strategies, plan-regression, and golden transcript tests
+## Features
 
-### Development
-- [Contributing](Contributing) - How to contribute to pgxkit
-- [FAQ](FAQ) - Frequently asked questions
+- Connection pool with optional read/write split (`Connect` / `ConnectReadWrite`).
+- Extensible hook system: `BeforeOperation`, `AfterOperation`, `BeforeTransaction`, `AfterTransaction`, `OnShutdown`, plus pgx connection-lifecycle hooks. `AfterOperation` receives the `pgconn.CommandTag` for Exec.
+- Retry helpers: `RetryOperation` and the typed `Retry[T]`, with PostgreSQL-aware error classification.
+- Plan-regression testing (`EnableAssertPlan` / `AssertPlan`) and golden-transcript testing (`EnableGolden` / `AssertGolden`).
+- Graceful shutdown with active-operation tracking.
+- Type helpers for clean conversion between Go and pgx types.
 
-## Key Features
-
-- **Type-safe operations** with Go generics
-- **Connection pooling** with read/write splitting
-- **Plan-regression testing** to catch query plan shape changes
-- **Golden transcript testing** to catch behavioral changes (extra/missing/reordered statements, different args, different rows)
-- **Extensible hooks** for monitoring and logging
-- **Production-ready** with graceful shutdown
-- **Zero dependencies** beyond pgx
-
-## Quick Start
+## Quick start
 
 ```go
 package main
@@ -36,46 +30,35 @@ package main
 import (
     "context"
     "log"
-    
-    "github.com/nhalm/pgxkit"
+
+    "github.com/nhalm/pgxkit/v2"
 )
 
 func main() {
-    // Connect to database
+    ctx := context.Background()
     db := pgxkit.NewDB()
-    err := db.Connect(context.Background(), "postgres://user:pass@localhost/db")
-    if err != nil {
+    if err := db.Connect(ctx, "postgres://user:pass@localhost/db"); err != nil {
         log.Fatal(err)
     }
-    defer db.Shutdown(context.Background())
-    
-    // Execute a query
+    defer db.Shutdown(ctx)
+
     var name string
-    err = db.QueryRow(context.Background(), 
-        "SELECT name FROM users WHERE id = $1", 1).Scan(&name)
-    if err != nil {
+    if err := db.QueryRow(ctx, "SELECT name FROM users WHERE id = $1", 1).Scan(&name); err != nil {
         log.Fatal(err)
     }
-    
-    log.Printf("User name: %s", name)
+    log.Println(name)
 }
 ```
 
-## Repository Information
+## Module
 
-- **GitHub**: [https://github.com/nhalm/pgxkit](https://github.com/nhalm/pgxkit)
-- **Go Module**: `github.com/nhalm/pgxkit`
-- **License**: MIT
-- **Go Version**: 1.21+
+- Module path: `github.com/nhalm/pgxkit/v2`
+- Go: 1.25+
+- License: MIT
+- Dependencies: `pgx`, `google/uuid`, `pmezard/go-difflib`
 
-## Community
+## Links
 
-- [Issues](https://github.com/nhalm/pgxkit/issues) - Report bugs or request features
-- [Discussions](https://github.com/nhalm/pgxkit/discussions) - Community discussions
-- [Pull Requests](https://github.com/nhalm/pgxkit/pulls) - Contribute code
+- [Repo](https://github.com/nhalm/pgxkit) · [Go package](https://pkg.go.dev/github.com/nhalm/pgxkit/v2) · [Issues](https://github.com/nhalm/pgxkit/issues)
 
-## Recent Updates
-
-This wiki is actively maintained and synchronized with the repository documentation. Check the [repository releases](https://github.com/nhalm/pgxkit/releases) for the latest updates.
-
---- 
+---

--- a/docs/Performance-Guide.md
+++ b/docs/Performance-Guide.md
@@ -1,833 +1,143 @@
-# Performance Optimization Guide
+# Performance Guide
 
 **[← Back to Home](Home)**
 
-This guide covers strategies and techniques for optimizing database performance when using pgxkit in your applications.
+What pgxkit gives you for performance: pool sizing knobs, `db.Stats()` for monitoring, hooks for timing, and `AssertPlan` to catch query-plan regressions in CI. Caching, indexing strategy, and SQL tuning are application concerns — pgxkit doesn't ship those.
 
-## Table of Contents
+## Pool sizing
 
-1. [Performance Fundamentals](#performance-fundamentals)
-2. [Connection Pool Optimization](#connection-pool-optimization)
-3. [Query Optimization](#query-optimization)
-4. [Read/Write Splitting](#readwrite-splitting)
-5. [Caching Strategies](#caching-strategies)
-6. [Monitoring and Profiling](#monitoring-and-profiling)
-7. [Plan-Regression Testing for Performance](#plan-regression-testing-for-performance)
-8. [Database Schema Optimization](#database-schema-optimization)
-9. [Application-Level Optimizations](#application-level-optimizations)
-10. [Troubleshooting Performance Issues](#troubleshooting-performance-issues)
-
-## Performance Fundamentals
-
-### Understanding Database Performance
-
-Key metrics to monitor:
-- **Query execution time** - How long individual queries take
-- **Connection pool utilization** - How efficiently connections are used
-- **Throughput** - Queries per second your application can handle
-- **Latency** - Time from request to response
-- **Resource usage** - CPU, memory, and I/O consumption
-
-### Performance Principles
-
-1. **Measure first** - Always profile before optimizing
-2. **Optimize the bottleneck** - Focus on the slowest component
-3. **Use appropriate data structures** - Choose the right tool for the job
-4. **Minimize database round trips** - Batch operations when possible
-5. **Cache frequently accessed data** - Reduce database load
-6. **Use indexes effectively** - Speed up query execution
-7. **Monitor continuously** - Performance can degrade over time
-
-## Connection Pool Optimization
-
-### Pool Size Configuration
+Start with `runtime.NumCPU() * 2` for CPU-bound, `* 4` for I/O-bound, then tune from observed `db.Stats()` under load.
 
 ```go
-func optimizeConnectionPool() *pgxkit.DB {
-    // Calculate optimal pool size based on workload
-    cpuCores := runtime.NumCPU()
-
-    // For CPU-bound workloads: 1-2 connections per core
-    // For I/O-bound workloads: 2-4 connections per core
-    maxConns := cpuCores * 3
-
-    // Configure DSN with connection pool parameters
-    dsn := fmt.Sprintf("%s?pool_max_conns=%d&pool_min_conns=%d&pool_max_conn_lifetime=1h&pool_max_conn_idle_time=30m&pool_health_check_period=1m",
-        pgxkit.GetDSN(),
-        maxConns,
-        maxConns/4, // Keep 25% as minimum
-    )
-
-    db := pgxkit.NewDB()
-    err := db.Connect(context.Background(), dsn)
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    return db
-}
+dsn := fmt.Sprintf(
+    "%s?pool_max_conns=%d&pool_min_conns=%d&pool_max_conn_lifetime=1h&pool_max_conn_idle_time=30m",
+    pgxkit.GetDSN(), 25, 5,
+)
+db := pgxkit.NewDB()
+_ = db.Connect(ctx, dsn)
 ```
 
-### Pool Monitoring
+Note: pgxpool sizes are fixed at connect time. There's no in-place "scale up" — to change pool size, reconnect.
+
+## Monitoring
+
+`db.Stats()` (and `db.ReadStats()` for the read pool) returns a `*pgxpool.Stat`:
 
 ```go
-func monitorConnectionPool(db *pgxkit.DB) {
-    ticker := time.NewTicker(30 * time.Second)
-    defer ticker.Stop()
-
-    for range ticker.C {
-        stats := db.Stats()
-        if stats == nil {
-            continue
-        }
-
-        // Calculate metrics
-        utilization := float64(stats.AcquiredConns()) / float64(stats.MaxConns())
-        idleRatio := float64(stats.IdleConns()) / float64(stats.TotalConns())
-
-        log.Printf("Pool Stats: Utilization=%.2f%%, Idle=%.2f%%, Total=%d, Max=%d",
-            utilization*100, idleRatio*100, stats.TotalConns(), stats.MaxConns())
-
-        // Alerts for performance issues
-        if utilization > 0.8 {
-            log.Printf("WARNING: High pool utilization (%.2f%%) - consider scaling", utilization*100)
-        }
-
-        if idleRatio > 0.7 {
-            log.Printf("INFO: High idle connections (%.2f%%) - consider reducing pool size", idleRatio*100)
-        }
-
-        // Track connection creation rate
-        if stats.NewConnsCount() > 0 {
-            log.Printf("New connections created: %d", stats.NewConnsCount())
-        }
-    }
-}
+stats := db.Stats()
+slog.Info("pool",
+    "acquired", stats.AcquiredConns(),
+    "idle",     stats.IdleConns(),
+    "max",      stats.MaxConns(),
+)
 ```
 
-### Dynamic Pool Sizing
+Key signals:
+
+- `AcquiredConns / MaxConns > 0.8` for sustained periods — increase pool size or fix connection leaks (forgotten `rows.Close()`).
+- `IdleConns / TotalConns > 0.7` consistently — pool is oversized.
+- Rising `NewConnsCount` — connections are being recycled too aggressively (raise `pool_max_conn_lifetime`).
+
+## Per-query timing via hooks
+
+Stash the start time on the context in `BeforeOperation`, read it back in `AfterOperation`:
 
 ```go
-type AdaptivePoolManager struct {
-    db               *pgxkit.DB
-    targetUtilization float64
-    scaleUpThreshold  float64
-    scaleDownThreshold float64
-    minConns         int32
-    maxConns         int32
-}
-
-func NewAdaptivePoolManager(db *pgxkit.DB) *AdaptivePoolManager {
-    return &AdaptivePoolManager{
-        db:               db,
-        targetUtilization: 0.7,
-        scaleUpThreshold:  0.8,
-        scaleDownThreshold: 0.3,
-        minConns:         5,
-        maxConns:         100,
-    }
-}
-
-func (apm *AdaptivePoolManager) adjustPoolSize() {
-    stats := apm.db.Stats()
-    if stats == nil {
-        return
-    }
-
-    utilization := float64(stats.AcquiredConns()) / float64(stats.MaxConns())
-
-    if utilization > apm.scaleUpThreshold && stats.MaxConns() < apm.maxConns {
-        // Scale up
-        newSize := int32(float64(stats.MaxConns()) * 1.2)
-        if newSize > apm.maxConns {
-            newSize = apm.maxConns
-        }
-        log.Printf("Scaling up pool size to %d (utilization: %.2f%%)", newSize, utilization*100)
-        // Note: Actual implementation would require reconnecting with new DSN parameters
-    } else if utilization < apm.scaleDownThreshold && stats.MaxConns() > apm.minConns {
-        // Scale down
-        newSize := int32(float64(stats.MaxConns()) * 0.8)
-        if newSize < apm.minConns {
-            newSize = apm.minConns
-        }
-        log.Printf("Scaling down pool size to %d (utilization: %.2f%%)", newSize, utilization*100)
-        // Note: Actual implementation would require reconnecting with new DSN parameters
-    }
-}
-```
-
-## Query Optimization
-
-### Efficient Query Patterns
-
-```go
-// Good: Use specific columns instead of SELECT *
-func getActiveUsers(db *pgxkit.DB) ([]User, error) {
-    rows, err := db.ReadQuery(context.Background(), `
-        SELECT id, name, email, created_at
-        FROM users
-        WHERE active = true
-        ORDER BY created_at DESC
-        LIMIT 100
-    `)
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
-
-    var users []User
-    for rows.Next() {
-        var user User
-        if err := rows.Scan(&user.ID, &user.Name, &user.Email, &user.CreatedAt); err != nil {
-            return nil, err
-        }
-        users = append(users, user)
-    }
-
-    return users, nil
-}
-
-// Good: Use EXISTS instead of COUNT for existence checks
-func userExists(db *pgxkit.DB, email string) (bool, error) {
-    var exists bool
-    err := db.ReadQueryRow(context.Background(), `
-        SELECT EXISTS(SELECT 1 FROM users WHERE email = $1)
-    `, email).Scan(&exists)
-
-    return exists, err
-}
-```
-
-### Batch Operations
-
-```go
-// Efficient bulk insert
-func createUsersBatch(db *pgxkit.DB, users []User) error {
-    ctx := context.Background()
-
-    tx, err := db.BeginTx(ctx, pgx.TxOptions{})
-    if err != nil {
-        return err
-    }
-    defer tx.Rollback(ctx)
-
-    // Use COPY for large batches (1000+ records)
-    if len(users) > 1000 {
-        return createUsersWithCopy(tx, users)
-    }
-
-    // Use batch insert for smaller sets
-    batch := &pgx.Batch{}
-    for _, user := range users {
-        batch.Queue("INSERT INTO users (name, email) VALUES ($1, $2)", user.Name, user.Email)
-    }
-
-    results := tx.SendBatch(ctx, batch)
-    defer results.Close()
-
-    // Process results
-    for i := 0; i < len(users); i++ {
-        _, err := results.Exec()
+type ctxKey struct{}
+db.Connect(ctx, "",
+    pgxkit.WithBeforeOperation(func(ctx context.Context, _ string, _ []interface{}, _ pgconn.CommandTag, _ error) error {
+        // store in ctx via your own mechanism, or use a request-scoped sync.Map keyed by goroutine
+        return nil
+    }),
+    pgxkit.WithAfterOperation(func(ctx context.Context, sql string, _ []interface{}, _ pgconn.CommandTag, err error) error {
+        metrics.QueryDuration.Observe(time.Since(startFromCtx(ctx)).Seconds())
         if err != nil {
-            return fmt.Errorf("failed to insert user %d: %w", i, err)
+            metrics.QueryErrors.Inc()
         }
-    }
-
-    return tx.Commit(ctx)
-}
-
-// COPY for very large datasets
-func createUsersWithCopy(tx pgx.Tx, users []User) error {
-    ctx := context.Background()
-
-    _, err := tx.CopyFrom(ctx,
-        pgx.Identifier{"users"},
-        []string{"name", "email"},
-        pgx.CopyFromSlice(len(users), func(i int) ([]interface{}, error) {
-            return []interface{}{users[i].Name, users[i].Email}, nil
-        }),
-    )
-
-    return err
-}
+        return nil
+    }),
+)
 ```
 
-### Query Caching
+The hook signature is in [API Reference](API-Reference#hookfunc).
+
+## Read/write split
+
+Routes reads to a replica, writes to the primary. Use it when reads dominate and you can tolerate replica lag.
 
 ```go
-type QueryCache struct {
-    cache map[string]CacheEntry
-    mutex sync.RWMutex
-    ttl   time.Duration
-}
-
-type CacheEntry struct {
-    Data      interface{}
-    ExpiresAt time.Time
-}
-
-func NewQueryCache(ttl time.Duration) *QueryCache {
-    return &QueryCache{
-        cache: make(map[string]CacheEntry),
-        ttl:   ttl,
-    }
-}
-
-func (qc *QueryCache) Get(key string) (interface{}, bool) {
-    qc.mutex.RLock()
-    defer qc.mutex.RUnlock()
-
-    entry, exists := qc.cache[key]
-    if !exists || time.Now().After(entry.ExpiresAt) {
-        return nil, false
-    }
-
-    return entry.Data, true
-}
-
-// Cached query example
-func getCachedUser(db *pgxkit.DB, cache *QueryCache, userID int) (*User, error) {
-    cacheKey := fmt.Sprintf("user:%d", userID)
-
-    // Check cache first
-    if cached, found := cache.Get(cacheKey); found {
-        return cached.(*User), nil
-    }
-
-    // Query database
-    var user User
-    err := db.ReadQueryRow(context.Background(),
-        "SELECT id, name, email FROM users WHERE id = $1",
-        userID).Scan(&user.ID, &user.Name, &user.Email)
-    if err != nil {
-        return nil, err
-    }
-
-    // Cache result
-    cache.Set(cacheKey, &user)
-
-    return &user, nil
-}
+_ = db.ConnectReadWrite(ctx, readDSN, writeDSN)
+rows, _ := db.ReadQuery(ctx, "SELECT ...")  // replica
+_, _   = db.Exec(ctx, "INSERT ...")         // primary
 ```
 
-## Read/Write Splitting
+`db.ReadStats()` reports the read pool separately.
 
-### Optimal Read/Write Configuration
+## Catching plan regressions in CI
+
+`AssertPlan` captures `EXPLAIN (FORMAT JSON, COSTS OFF)` per query and compares to a checked-in baseline. A plan flip — index-scan → seq-scan, hash-join → nested-loop, an extra sort, a different join order — fails the test with a unified diff.
 
 ```go
-func createOptimizedReadWriteDB() *pgxkit.DB {
-    // Write pool configuration (smaller, optimized for consistency)
-    writeDSN := fmt.Sprintf("%s?pool_max_conns=20&pool_min_conns=5&pool_max_conn_lifetime=2h",
-        getWriteDSN())
+func TestUserSearch_Plan(t *testing.T) {
+    testDB := pgxkit.RequireDB(t)
+    db := testDB.EnableAssertPlan("TestUserSearch")
 
-    // Read pool configuration (larger, optimized for throughput)
-    readDSN := fmt.Sprintf("%s?pool_max_conns=50&pool_min_conns=10&pool_max_conn_lifetime=1h&pool_max_conn_idle_time=15m",
-        getReadDSN())
+    rows, err := db.Query(ctx, `
+        SELECT u.id, u.name, COUNT(o.id)
+        FROM users u LEFT JOIN orders o ON u.id = o.user_id
+        WHERE u.name ILIKE $1
+        GROUP BY u.id, u.name
+        ORDER BY 3 DESC
+        LIMIT 50
+    `, "%john%")
+    require.NoError(t, err)
+    rows.Close()
 
-    db := pgxkit.NewDB()
-    err := db.ConnectReadWrite(context.Background(), readDSN, writeDSN)
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    return db
+    db.AssertPlan(t, "TestUserSearch")
 }
 ```
 
-### Smart Query Routing
+Baselines live at `testdata/plans/<name>.json`. Refresh after intentional schema or query changes: `go test -overwrite-plan`.
+
+## Bulk operations
+
+For thousands of rows, `tx.Tx().CopyFrom` beats batched INSERTs by an order of magnitude. For moderate sizes, `pgx.Batch` halves the round-trip cost.
 
 ```go
-type QueryRouter struct {
-    db *pgxkit.DB
-}
-
-func NewQueryRouter(db *pgxkit.DB) *QueryRouter {
-    return &QueryRouter{db: db}
-}
-
-func (qr *QueryRouter) ExecuteQuery(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
-    // Route based on query type
-    if isReadQuery(sql) {
-        return qr.db.ReadQuery(ctx, sql, args...)
-    }
-    return qr.db.Query(ctx, sql, args...)
-}
-
-func isReadQuery(sql string) bool {
-    sql = strings.TrimSpace(strings.ToUpper(sql))
-    return strings.HasPrefix(sql, "SELECT") ||
-           strings.HasPrefix(sql, "WITH") ||
-           strings.HasPrefix(sql, "SHOW") ||
-           strings.HasPrefix(sql, "EXPLAIN")
-}
+tx, _ := db.BeginTx(ctx, pgx.TxOptions{})
+defer tx.Rollback(ctx)
+_, err := tx.Tx().CopyFrom(ctx,
+    pgx.Identifier{"users"}, []string{"name", "email"},
+    pgx.CopyFromSlice(len(rows), func(i int) ([]any, error) {
+        return []any{rows[i].Name, rows[i].Email}, nil
+    }),
+)
 ```
 
-## Caching Strategies
+## Streaming large result sets
 
-### Multi-Level Caching
+Don't accumulate large queries into a slice. Iterate and process:
 
 ```go
-type CacheManager struct {
-    l1Cache *sync.Map           // In-memory cache
-    l2Cache *redis.Client       // Redis cache
-    db      *pgxkit.DB
+rows, err := db.ReadQuery(ctx, "SELECT id, payload FROM events WHERE day = $1", day)
+if err != nil { return err }
+defer rows.Close()
+for rows.Next() {
+    var e Event
+    if err := rows.Scan(&e.ID, &e.Payload); err != nil { return err }
+    if err := process(&e); err != nil { return err }
 }
-
-func NewCacheManager(db *pgxkit.DB, redisClient *redis.Client) *CacheManager {
-    return &CacheManager{
-        l1Cache: &sync.Map{},
-        l2Cache: redisClient,
-        db:      db,
-    }
-}
-
-func (cm *CacheManager) GetUser(ctx context.Context, userID int) (*User, error) {
-    cacheKey := fmt.Sprintf("user:%d", userID)
-
-    // L1 Cache (in-memory)
-    if cached, found := cm.l1Cache.Load(cacheKey); found {
-        return cached.(*User), nil
-    }
-
-    // L2 Cache (Redis)
-    if cm.l2Cache != nil {
-        cached, err := cm.l2Cache.Get(ctx, cacheKey).Result()
-        if err == nil {
-            var user User
-            if err := json.Unmarshal([]byte(cached), &user); err == nil {
-                // Store in L1 cache
-                cm.l1Cache.Store(cacheKey, &user)
-                return &user, nil
-            }
-        }
-    }
-
-    // Database query
-    var user User
-    err := cm.db.ReadQueryRow(ctx,
-        "SELECT id, name, email FROM users WHERE id = $1",
-        userID).Scan(&user.ID, &user.Name, &user.Email)
-    if err != nil {
-        return nil, err
-    }
-
-    // Store in caches
-    cm.l1Cache.Store(cacheKey, &user)
-    if cm.l2Cache != nil {
-        if data, err := json.Marshal(user); err == nil {
-            cm.l2Cache.Set(ctx, cacheKey, data, 5*time.Minute)
-        }
-    }
-
-    return &user, nil
-}
+return rows.Err()
 ```
 
-### Cache Invalidation
-
-```go
-func (cm *CacheManager) InvalidateUser(ctx context.Context, userID int) {
-    cacheKey := fmt.Sprintf("user:%d", userID)
-
-    // Remove from L1 cache
-    cm.l1Cache.Delete(cacheKey)
-
-    // Remove from L2 cache
-    if cm.l2Cache != nil {
-        cm.l2Cache.Del(ctx, cacheKey)
-    }
-}
-
-// Automatic cache invalidation with hooks
-func setupCacheInvalidationDB(cache *CacheManager) *pgxkit.DB {
-    db := pgxkit.NewDB()
-    err := db.Connect(context.Background(), pgxkit.GetDSN(),
-        pgxkit.WithAfterOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-            if operationErr != nil {
-                return nil // Don't invalidate on error
-            }
-
-            // Parse SQL to determine what to invalidate
-            if isUserModification(sql) {
-                // Extract user ID from args and invalidate
-                if len(args) > 0 {
-                    if userID, ok := args[0].(int); ok {
-                        cache.InvalidateUser(ctx, userID)
-                    }
-                }
-            }
-
-            return nil
-        }),
-    )
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    return db
-}
-```
-
-## Monitoring and Profiling
-
-### Performance Metrics Collection
-
-```go
-type PerformanceMetrics struct {
-    QueryDuration    *prometheus.HistogramVec
-    QueryCounter     *prometheus.CounterVec
-    PoolUtilization  *prometheus.GaugeVec
-    CacheHitRate     *prometheus.GaugeVec
-}
-
-func NewPerformanceMetrics() *PerformanceMetrics {
-    return &PerformanceMetrics{
-        QueryDuration: prometheus.NewHistogramVec(
-            prometheus.HistogramOpts{
-                Name: "pgxkit_query_duration_seconds",
-                Help: "Query execution duration",
-                Buckets: []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0},
-            },
-            []string{"operation", "table", "status"},
-        ),
-        QueryCounter: prometheus.NewCounterVec(
-            prometheus.CounterOpts{
-                Name: "pgxkit_queries_total",
-                Help: "Total number of queries",
-            },
-            []string{"operation", "table", "status"},
-        ),
-        PoolUtilization: prometheus.NewGaugeVec(
-            prometheus.GaugeOpts{
-                Name: "pgxkit_pool_utilization",
-                Help: "Connection pool utilization",
-            },
-            []string{"pool_type"},
-        ),
-        CacheHitRate: prometheus.NewGaugeVec(
-            prometheus.GaugeOpts{
-                Name: "pgxkit_cache_hit_rate",
-                Help: "Cache hit rate",
-            },
-            []string{"cache_level"},
-        ),
-    }
-}
-
-func setupPerformanceMonitoringDB(metrics *PerformanceMetrics) *pgxkit.DB {
-    db := pgxkit.NewDB()
-    err := db.Connect(context.Background(), pgxkit.GetDSN(),
-        pgxkit.WithAfterOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-            start, ok := ctx.Value("perf_start").(time.Time)
-            if !ok {
-                return nil
-            }
-
-            duration := time.Since(start)
-            operation := extractOperation(sql)
-            table := extractTable(sql)
-            status := "success"
-            if operationErr != nil {
-                status = "error"
-            }
-
-            metrics.QueryDuration.WithLabelValues(operation, table, status).Observe(duration.Seconds())
-            metrics.QueryCounter.WithLabelValues(operation, table, status).Inc()
-
-            return nil
-        }),
-    )
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    return db
-}
-```
-
-## Plan-Regression Testing for Performance
-
-Plan-regression testing captures the structural query plan via `EXPLAIN (FORMAT JSON, COSTS OFF)` and asserts it is unchanged across runs. It catches plan shape changes that often correlate with performance regressions (seq-scan to index-scan, nested-loop to hash-join, a new sort node, a different join order). It does NOT assert anything about query result rows.
-
-### Catching Plan Regressions Automatically
-
-```go
-func TestQueryPerformance(t *testing.T) {
-    testDB := setupTestDB(t)
-
-    // Enable plan-regression testing to capture structural EXPLAIN plans
-    db := testDB.EnableAssertPlan("TestQueryPerformance")
-
-    // Create test data
-    createTestData(t, testDB, 10000)
-
-    // Test critical queries
-    t.Run("user_search_performance", func(t *testing.T) {
-        // This query's structural EXPLAIN plan will be captured and asserted
-        rows, err := db.Query(context.Background(), `
-            SELECT u.id, u.name, u.email, COUNT(o.id) as order_count
-            FROM users u
-            LEFT JOIN orders o ON u.id = o.user_id
-            WHERE u.name ILIKE $1
-            GROUP BY u.id, u.name, u.email
-            ORDER BY order_count DESC
-            LIMIT 50
-        `, "%john%")
-        if err != nil {
-            t.Fatal(err)
-        }
-        defer rows.Close()
-
-        // Verify results
-        var count int
-        for rows.Next() {
-            count++
-        }
-
-        if count == 0 {
-            t.Error("Expected search results")
-        }
-    })
-
-    db.AssertPlan(t, "TestQueryPerformance")
-}
-```
-
-## Database Schema Optimization
-
-### Index Optimization
-
-```sql
--- Create indexes for common query patterns
-CREATE INDEX CONCURRENTLY idx_users_email ON users(email);
-CREATE INDEX CONCURRENTLY idx_users_active_created ON users(active, created_at DESC);
-CREATE INDEX CONCURRENTLY idx_orders_user_created ON orders(user_id, created_at DESC);
-
--- Partial indexes for specific conditions
-CREATE INDEX CONCURRENTLY idx_users_active ON users(id) WHERE active = true;
-CREATE INDEX CONCURRENTLY idx_orders_recent ON orders(created_at DESC)
-    WHERE created_at > NOW() - INTERVAL '30 days';
-
--- Composite indexes for complex queries
-CREATE INDEX CONCURRENTLY idx_users_search ON users
-    USING gin(to_tsvector('english', name || ' ' || email));
-```
-
-### Query Plan Analysis
-
-```go
-func analyzeQueryPlan(db *pgxkit.DB, sql string, args ...interface{}) {
-    ctx := context.Background()
-
-    // Get query plan
-    explainSQL := "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) " + sql
-    row := db.QueryRow(ctx, explainSQL, args...)
-
-    var planJSON string
-    err := row.Scan(&planJSON)
-    if err != nil {
-        log.Printf("Failed to get query plan: %v", err)
-        return
-    }
-
-    // Parse and analyze plan
-    var plan map[string]interface{}
-    if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-        log.Printf("Failed to parse query plan: %v", err)
-        return
-    }
-
-    // Extract key metrics
-    if plans, ok := plan["Plan"].([]interface{}); ok && len(plans) > 0 {
-        if planData, ok := plans[0].(map[string]interface{}); ok {
-            executionTime := planData["Actual Total Time"]
-            planningTime := plan["Planning Time"]
-
-            log.Printf("Query: %s", sql)
-            log.Printf("Execution Time: %v ms", executionTime)
-            log.Printf("Planning Time: %v ms", planningTime)
-
-            // Check for performance issues
-            if execTime, ok := executionTime.(float64); ok && execTime > 1000 {
-                log.Printf("WARNING: Slow query detected (%.2f ms)", execTime)
-            }
-        }
-    }
-}
-```
-
-## Application-Level Optimizations
-
-### Connection Reuse
-
-```go
-type ConnectionManager struct {
-    db *pgxkit.DB
-}
-
-func (cm *ConnectionManager) ExecuteInTransaction(ctx context.Context, fn func(tx pgx.Tx) error) error {
-    tx, err := cm.db.BeginTx(ctx, pgx.TxOptions{})
-    if err != nil {
-        return err
-    }
-    defer tx.Rollback(ctx)
-
-    if err := fn(tx); err != nil {
-        return err
-    }
-
-    return tx.Commit(ctx)
-}
-
-// Batch multiple operations in a single transaction
-func (cm *ConnectionManager) CreateUserWithProfile(ctx context.Context, user *User, profile *Profile) error {
-    return cm.ExecuteInTransaction(ctx, func(tx pgx.Tx) error {
-        // Insert user
-        err := tx.QueryRow(ctx,
-            "INSERT INTO users (name, email) VALUES ($1, $2) RETURNING id",
-            user.Name, user.Email).Scan(&user.ID)
-        if err != nil {
-            return err
-        }
-
-        // Insert profile
-        _, err = tx.Exec(ctx,
-            "INSERT INTO profiles (user_id, bio, avatar) VALUES ($1, $2, $3)",
-            user.ID, profile.Bio, profile.Avatar)
-        return err
-    })
-}
-```
-
-### Result Set Streaming
-
-```go
-func streamLargeResultSet(db *pgxkit.DB, processor func(*User) error) error {
-    ctx := context.Background()
-
-    rows, err := db.ReadQuery(ctx, `
-        SELECT id, name, email
-        FROM users
-        ORDER BY id
-    `)
-    if err != nil {
-        return err
-    }
-    defer rows.Close()
-
-    for rows.Next() {
-        var user User
-        if err := rows.Scan(&user.ID, &user.Name, &user.Email); err != nil {
-            return err
-        }
-
-        // Process each user immediately
-        if err := processor(&user); err != nil {
-            return err
-        }
-    }
-
-    return rows.Err()
-}
-```
-
-## Troubleshooting Performance Issues
-
-### Common Performance Problems
-
-1. **Connection Pool Exhaustion**
-```go
-// Symptoms: High latency, timeouts
-// Solution: Increase pool size or fix connection leaks
-func diagnosePoolExhaustion(db *pgxkit.DB) {
-    stats := db.Stats()
-    if stats.AcquiredConns() >= stats.MaxConns() {
-        log.Printf("Pool exhausted: %d/%d connections", stats.AcquiredConns(), stats.MaxConns())
-        // Check for connection leaks
-        // Increase pool size if needed
-    }
-}
-```
-
-2. **Slow Queries**
-```go
-// Use query analyzer to identify problematic queries
-func identifySlowQueries(analyzer *QueryAnalyzer) {
-    slowQueries := analyzer.GetSlowQueries()
-    for _, query := range slowQueries {
-        avgDuration := query.TotalDuration / time.Duration(query.Count)
-        log.Printf("Slow query: %s (avg: %v, count: %d)",
-            query.SQL, avgDuration, query.Count)
-    }
-}
-```
-
-3. **Memory Issues**
-```go
-// Monitor memory usage
-func monitorMemoryUsage() {
-    var m runtime.MemStats
-    runtime.ReadMemStats(&m)
-
-    log.Printf("Memory Stats: Alloc=%d KB, TotalAlloc=%d KB, Sys=%d KB, NumGC=%d",
-        bToKb(m.Alloc), bToKb(m.TotalAlloc), bToKb(m.Sys), m.NumGC)
-}
-
-func bToKb(b uint64) uint64 {
-    return b / 1024
-}
-```
-
-### Performance Debugging Checklist
-
-- [ ] Check connection pool utilization
-- [ ] Analyze slow query logs
-- [ ] Verify index usage
-- [ ] Monitor memory consumption
-- [ ] Check for connection leaks
-- [ ] Validate query patterns
-- [ ] Review caching effectiveness
-- [ ] Assess read/write split efficiency
-- [ ] Monitor database server metrics
-- [ ] Check network latency
-
-### Performance Tuning Tips
-
-1. **Query Optimization**
-   - Use EXPLAIN ANALYZE to understand query plans
-   - Add appropriate indexes
-   - Avoid SELECT * queries
-   - Use LIMIT for large result sets
-
-2. **Connection Management**
-   - Right-size connection pools
-   - Monitor pool utilization
-   - Use read/write splitting
-   - Implement connection retry logic
-
-3. **Caching Strategy**
-   - Cache frequently accessed data
-   - Use appropriate cache TTLs
-   - Implement cache invalidation
-   - Consider multi-level caching
-
-4. **Application Design**
-   - Batch operations when possible
-   - Use transactions appropriately
-   - Stream large result sets
-   - Implement proper error handling
-
-## See Also
-
-- **[Getting Started](Getting-Started)** - Basic setup and configuration
-- **[Examples](Examples)** - Practical code examples
-- **[Production Guide](Production-Guide)** - Deployment and production considerations
-- **[Testing Guide](Testing-Guide)** - Testing strategies and plan-regression tests
-- **[API Reference](API-Reference)** - Complete API documentation
+## Performance checklist
+
+- Always `defer rows.Close()`.
+- Bound queries with `context.WithTimeout`.
+- Project specific columns; avoid `SELECT *`.
+- Add indexes for predicates and join keys; check with `EXPLAIN ANALYZE`.
+- Add `AssertPlan` baselines for the queries that matter.
 
 ---
 
 **[← Back to Home](Home)**
-
-*Following these performance optimization strategies will help you build high-performance applications with pgxkit while maintaining reliability and scalability.*
-

--- a/docs/Production-Guide.md
+++ b/docs/Production-Guide.md
@@ -1,842 +1,124 @@
-# Production Deployment Guide
+# Production Guide
 
 **[← Back to Home](Home)**
 
-This guide covers best practices for deploying pgxkit applications in production environments.
+What pgxkit handles for production: pool config, hooks, retries, `db.HealthCheck`, `db.Shutdown` with active-operation tracking. Container orchestration, deployment patterns, alerting, and circuit breakers belong in your infrastructure layer.
 
-## Table of Contents
-
-1. [Environment Configuration](#environment-configuration)
-2. [Connection Pool Optimization](#connection-pool-optimization)
-3. [Monitoring and Observability](#monitoring-and-observability)
-4. [Security Best Practices](#security-best-practices)
-5. [Scaling Strategies](#scaling-strategies)
-6. [Health Checks and Readiness](#health-checks-and-readiness)
-7. [Graceful Shutdown](#graceful-shutdown)
-8. [Error Handling and Recovery](#error-handling-and-recovery)
-9. [Performance Optimization](#performance-optimization)
-10. [Deployment Patterns](#deployment-patterns)
-
-## Environment Configuration
-
-### Database Connection Settings
-
-Configure these environment variables for production:
-
-```bash
-# Database Connection
-POSTGRES_HOST=your-db-host.com
-POSTGRES_PORT=5432
-POSTGRES_USER=your-app-user
-POSTGRES_PASSWORD=your-secure-password
-POSTGRES_DB=your-production-db
-POSTGRES_SSLMODE=require
-
-# Connection Pool Settings
-POSTGRES_MAX_CONNS=30
-POSTGRES_MIN_CONNS=5
-POSTGRES_MAX_CONN_LIFETIME=1h
-POSTGRES_MAX_CONN_IDLE_TIME=30m
-POSTGRES_HEALTH_CHECK_PERIOD=1m
-```
-
-### Application Configuration
+## Configuration
 
 ```go
-package main
-
-import (
-    "context"
-    "log"
-    "time"
-
-    "github.com/nhalm/pgxkit"
+db := pgxkit.NewDB()
+err := db.Connect(ctx, pgxkit.GetDSN(),
+    pgxkit.WithMaxConns(int32(runtime.NumCPU()*4)),
+    pgxkit.WithMinConns(int32(runtime.NumCPU())),
+    pgxkit.WithMaxConnLifetime(time.Hour),
+    pgxkit.WithMaxConnIdleTime(15*time.Minute),
 )
-
-func createProductionDB() *pgxkit.DB {
-    db := pgxkit.NewDB()
-
-    err := db.Connect(context.Background(), pgxkit.GetDSN(),
-        pgxkit.WithMaxConns(30),
-        pgxkit.WithMinConns(5),
-        pgxkit.WithMaxConnLifetime(time.Hour),
-        pgxkit.WithMaxConnIdleTime(30*time.Minute),
-    )
-    if err != nil {
-        log.Fatal("Failed to connect to database:", err)
-    }
-
-    return db
-}
 ```
 
-### Read/Write Split Configuration
+`pgxkit.GetDSN()` reads `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_SSLMODE`. For SSL, set `POSTGRES_SSLMODE=require` (or `verify-full` with `sslcert=`/`sslkey=`/`sslrootcert=` in the DSN).
+
+## Read/write split
 
 ```go
-func createProductionReadWriteDB() *pgxkit.DB {
-    // Read replicas (multiple for load balancing)
-    readDSN := fmt.Sprintf(
-        "postgres://%s:%s@%s:%s/%s?sslmode=require&pool_max_conns=50&pool_min_conns=10",
-        os.Getenv("POSTGRES_READ_USER"),
-        os.Getenv("POSTGRES_READ_PASSWORD"),
-        os.Getenv("POSTGRES_READ_HOST"),
-        os.Getenv("POSTGRES_PORT"),
-        os.Getenv("POSTGRES_DB"),
-    )
-
-    // Primary database (writes)
-    writeDSN := fmt.Sprintf(
-        "postgres://%s:%s@%s:%s/%s?sslmode=require&pool_max_conns=20&pool_min_conns=5",
-        os.Getenv("POSTGRES_WRITE_USER"),
-        os.Getenv("POSTGRES_WRITE_PASSWORD"),
-        os.Getenv("POSTGRES_WRITE_HOST"),
-        os.Getenv("POSTGRES_PORT"),
-        os.Getenv("POSTGRES_DB"),
-    )
-
-    db := pgxkit.NewDB()
-    err := db.ConnectReadWrite(context.Background(), readDSN, writeDSN)
-    if err != nil {
-        log.Fatal("Failed to connect to database:", err)
-    }
-
-    return db
-}
-```
-
-## Connection Pool Optimization
-
-### Production Pool Settings
-
-```go
-func createOptimizedDB(ctx context.Context) *pgxkit.DB {
-    cpuCores := int32(runtime.NumCPU())
-
-    db := pgxkit.NewDB()
-    err := db.Connect(ctx, pgxkit.GetDSN(),
-        pgxkit.WithMaxConns(cpuCores*4),
-        pgxkit.WithMinConns(cpuCores),
-        pgxkit.WithMaxConnLifetime(2*time.Hour),
-        pgxkit.WithMaxConnIdleTime(15*time.Minute),
-    )
-    if err != nil {
-        log.Fatal("Failed to connect:", err)
-    }
-
-    return db
-}
-```
-
-### Dynamic Pool Scaling
-
-```go
-type ProductionPoolManager struct {
-    db               *pgxkit.DB
-    metrics          *prometheus.Registry
-    alertManager     AlertManager
-    scaleUpThreshold float64
-    scaleDownThreshold float64
-}
-
-func (ppm *ProductionPoolManager) monitorAndScale() {
-    ticker := time.NewTicker(1 * time.Minute)
-    defer ticker.Stop()
-
-    for range ticker.C {
-        writeStats := ppm.db.Stats()
-        readStats := ppm.db.ReadStats()
-
-        ppm.evaluateScaling(writeStats, "write")
-        if readStats != nil {
-            ppm.evaluateScaling(readStats, "read")
-        }
-    }
-}
-
-func (ppm *ProductionPoolManager) evaluateScaling(stats *pgxpool.Stat, poolType string) {
-    utilization := float64(stats.AcquiredConns()) / float64(stats.MaxConns())
-
-    // Alert on high utilization
-    if utilization > 0.9 {
-        ppm.alertManager.SendAlert(fmt.Sprintf(
-            "High %s pool utilization: %.2f%% (%d/%d connections)",
-            poolType, utilization*100, stats.AcquiredConns(), stats.MaxConns()))
-    }
-
-    // Log pool statistics
-    log.Printf("%s pool: utilization=%.2f%%, acquired=%d, idle=%d, total=%d, max=%d",
-        poolType, utilization*100, stats.AcquiredConns(), stats.IdleConns(),
-        stats.TotalConns(), stats.MaxConns())
-}
-```
-
-## Monitoring and Observability
-
-### Production Logging
-
-```go
-import (
-    "log/slog"
-    "github.com/prometheus/client_golang/prometheus"
+_ = db.ConnectReadWrite(ctx,
+    "postgres://user:pass@replica/db?sslmode=require&pool_max_conns=50",
+    "postgres://user:pass@primary/db?sslmode=require&pool_max_conns=20",
 )
-
-func setupProductionDB() *pgxkit.DB {
-    logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-        Level: slog.LevelInfo,
-    }))
-
-    db := pgxkit.NewDB()
-    err := db.Connect(context.Background(), pgxkit.GetDSN(),
-        pgxkit.WithAfterOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-            operation := extractOperation(sql)
-
-            // Log slow queries
-            if start, ok := ctx.Value("start_time").(time.Time); ok {
-                duration := time.Since(start)
-                if duration > 100*time.Millisecond {
-                    logger.WarnContext(ctx, "slow query detected",
-                        slog.String("operation", operation),
-                        slog.Duration("duration", duration),
-                        slog.String("sql", sql),
-                    )
-                }
-            }
-
-            // Log errors
-            if operationErr != nil {
-                logger.ErrorContext(ctx, "database operation failed",
-                    slog.String("operation", operation),
-                    slog.String("error", operationErr.Error()),
-                    slog.String("sql", sql),
-                )
-            }
-
-            return nil
-        }),
-    )
-    if err != nil {
-        log.Fatal("Failed to connect:", err)
-    }
-
-    return db
-}
 ```
 
-### Prometheus Metrics
+`db.ReadStats()` reports the read pool separately from `db.Stats()`.
+
+## Health and readiness
 
 ```go
-var (
-    dbConnections = prometheus.NewGaugeVec(
-        prometheus.GaugeOpts{
-            Name: "pgxkit_connections",
-            Help: "Number of database connections",
-        },
-        []string{"pool", "state"},
-    )
-
-    queryDuration = prometheus.NewHistogramVec(
-        prometheus.HistogramOpts{
-            Name:    "pgxkit_query_duration_seconds",
-            Help:    "Database query duration",
-            Buckets: prometheus.ExponentialBuckets(0.001, 2, 20),
-        },
-        []string{"operation", "status"},
-    )
-
-    queryTotal = prometheus.NewCounterVec(
-        prometheus.CounterOpts{
-            Name: "pgxkit_queries_total",
-            Help: "Total number of database queries",
-        },
-        []string{"operation", "status"},
-    )
-)
-
-func setupMetricsDB() *pgxkit.DB {
-    prometheus.MustRegister(dbConnections, queryDuration, queryTotal)
-
-    db := pgxkit.NewDB()
-    err := db.Connect(context.Background(), pgxkit.GetDSN(),
-        pgxkit.WithAfterOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-            start, ok := ctx.Value("metrics_start").(time.Time)
-            if !ok {
-                return nil
-            }
-
-            duration := time.Since(start)
-            operation := extractOperation(sql)
-            status := "success"
-            if operationErr != nil {
-                status = "error"
-            }
-
-            queryDuration.WithLabelValues(operation, status).Observe(duration.Seconds())
-            queryTotal.WithLabelValues(operation, status).Inc()
-
-            return nil
-        }),
-    )
-    if err != nil {
-        log.Fatal("Failed to connect:", err)
-    }
-
-    // Pool metrics collection
-    go func() {
-        ticker := time.NewTicker(10 * time.Second)
-        defer ticker.Stop()
-
-        for range ticker.C {
-            collectPoolMetrics(db)
-        }
-    }()
-
-    return db
-}
-
-func collectPoolMetrics(db *pgxkit.DB) {
-    if stats := db.Stats(); stats != nil {
-        dbConnections.WithLabelValues("write", "acquired").Set(float64(stats.AcquiredConns()))
-        dbConnections.WithLabelValues("write", "idle").Set(float64(stats.IdleConns()))
-        dbConnections.WithLabelValues("write", "total").Set(float64(stats.TotalConns()))
-    }
-
-    if readStats := db.ReadStats(); readStats != nil {
-        dbConnections.WithLabelValues("read", "acquired").Set(float64(readStats.AcquiredConns()))
-        dbConnections.WithLabelValues("read", "idle").Set(float64(readStats.IdleConns()))
-        dbConnections.WithLabelValues("read", "total").Set(float64(readStats.TotalConns()))
-    }
-}
-```
-
-## Security Best Practices
-
-### SSL/TLS Configuration
-
-```go
-func setupSecureConnection() *pgxkit.DB {
-    // Always use SSL in production
-    dsn := fmt.Sprintf(
-        "postgres://%s:%s@%s:%s/%s?sslmode=require&sslcert=%s&sslkey=%s&sslrootcert=%s",
-        os.Getenv("POSTGRES_USER"),
-        os.Getenv("POSTGRES_PASSWORD"),
-        os.Getenv("POSTGRES_HOST"),
-        os.Getenv("POSTGRES_PORT"),
-        os.Getenv("POSTGRES_DB"),
-        os.Getenv("POSTGRES_SSL_CERT"),
-        os.Getenv("POSTGRES_SSL_KEY"),
-        os.Getenv("POSTGRES_SSL_ROOT_CERT"),
-    )
-
-    db := pgxkit.NewDB()
-    err := db.Connect(context.Background(), dsn)
-    if err != nil {
-        log.Fatal("Failed to connect securely:", err)
-    }
-
-    return db
-}
-```
-
-### Connection Security
-
-```go
-func validateConnection(db *pgxkit.DB) error {
-    ctx := context.Background()
-
-    // Verify SSL connection
-    var sslInUse bool
-    err := db.QueryRow(ctx, "SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()").Scan(&sslInUse)
-    if err != nil {
-        return fmt.Errorf("failed to check SSL status: %w", err)
-    }
-
-    if !sslInUse {
-        return fmt.Errorf("SSL connection required but not active")
-    }
-
-    // Verify user permissions
-    var currentUser string
-    err = db.QueryRow(ctx, "SELECT current_user").Scan(&currentUser)
-    if err != nil {
-        return fmt.Errorf("failed to get current user: %w", err)
-    }
-
-    log.Printf("Connected as user: %s with SSL enabled", currentUser)
-    return nil
-}
-```
-
-## Scaling Strategies
-
-### Horizontal Scaling
-
-```go
-type DatabaseCluster struct {
-    primary   *pgxkit.DB
-    replicas  []*pgxkit.DB
-    loadBalancer *ReadLoadBalancer
-}
-
-func NewDatabaseCluster(primaryDSN string, replicaDSNs []string) *DatabaseCluster {
-    // Connect to primary
-    primary := pgxkit.NewDB()
-    err := primary.Connect(context.Background(), primaryDSN)
-    if err != nil {
-        log.Fatal("Failed to connect to primary:", err)
-    }
-
-    // Connect to replicas
-    var replicas []*pgxkit.DB
-    for _, dsn := range replicaDSNs {
-        replica := pgxkit.NewDB()
-        err := replica.Connect(context.Background(), dsn)
-        if err != nil {
-            log.Printf("Failed to connect to replica %s: %v", dsn, err)
-            continue
-        }
-        replicas = append(replicas, replica)
-    }
-
-    return &DatabaseCluster{
-        primary:      primary,
-        replicas:     replicas,
-        loadBalancer: NewReadLoadBalancer(replicas),
-    }
-}
-
-func (dc *DatabaseCluster) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
-    if isReadQuery(sql) {
-        return dc.loadBalancer.Query(ctx, sql, args...)
-    }
-    return dc.primary.Query(ctx, sql, args...)
-}
-```
-
-### Connection Pooling at Scale
-
-```go
-func setupEnterpiseConnectionPool() *pgxkit.DB {
-    // Large-scale production settings
-    dsn := fmt.Sprintf("%s?"+
-        "pool_max_conns=100&"+
-        "pool_min_conns=20&"+
-        "pool_max_conn_lifetime=4h&"+
-        "pool_max_conn_idle_time=30m&"+
-        "pool_health_check_period=30s&"+
-        "pool_max_conn_lifetime_jitter=10m",
-        pgxkit.GetDSN())
-
-    db := pgxkit.NewDB()
-    err := db.Connect(context.Background(), dsn)
-    if err != nil {
-        log.Fatal("Failed to create enterprise pool:", err)
-    }
-
-    return db
-}
-```
-
-## Health Checks and Readiness
-
-### Kubernetes Health Check
-
-```go
-func healthCheckHandler(db *pgxkit.DB) http.HandlerFunc {
-    return func(w http.ResponseWriter, r *http.Request) {
-        ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
-        defer cancel()
-
-        // Check database connectivity
-        if err := db.HealthCheck(ctx); err != nil {
-            w.WriteHeader(http.StatusServiceUnavailable)
-            json.NewEncoder(w).Encode(map[string]interface{}{
-                "status": "unhealthy",
-                "error":  err.Error(),
-                "timestamp": time.Now().UTC(),
-            })
-            return
-        }
-
-        // Check pool statistics
-        stats := db.Stats()
-        utilization := float64(stats.AcquiredConns()) / float64(stats.MaxConns())
-
-        health := map[string]interface{}{
-            "status": "healthy",
-            "timestamp": time.Now().UTC(),
-            "database": map[string]interface{}{
-                "connected": true,
-                "pool_utilization": fmt.Sprintf("%.2f%%", utilization*100),
-                "active_connections": stats.AcquiredConns(),
-                "max_connections": stats.MaxConns(),
-            },
-        }
-
-        // Warning if utilization is high
-        if utilization > 0.8 {
-            health["warnings"] = []string{
-                fmt.Sprintf("High connection pool utilization: %.2f%%", utilization*100),
-            }
-        }
-
-        w.Header().Set("Content-Type", "application/json")
-        w.WriteHeader(http.StatusOK)
-        json.NewEncoder(w).Encode(health)
-    }
-}
-
-func readinessHandler(db *pgxkit.DB) http.HandlerFunc {
-    return func(w http.ResponseWriter, r *http.Request) {
-        ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
-        defer cancel()
-
-        // Simple connectivity test
-        var result int
-        err := db.QueryRow(ctx, "SELECT 1").Scan(&result)
-        if err != nil {
-            w.WriteHeader(http.StatusServiceUnavailable)
-            return
-        }
-
-        w.WriteHeader(http.StatusOK)
-        w.Write([]byte("ready"))
-    }
-}
-```
-
-## Graceful Shutdown
-
-### Production Shutdown Sequence
-
-```go
-func gracefulShutdown(db *pgxkit.DB, server *http.Server) {
-    c := make(chan os.Signal, 1)
-    signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-
-    <-c
-    log.Println("Received shutdown signal")
-
-    // Create shutdown context with timeout
-    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+    ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
     defer cancel()
-
-    // Shutdown HTTP server first
-    log.Println("Shutting down HTTP server...")
-    if err := server.Shutdown(ctx); err != nil {
-        log.Printf("HTTP server shutdown error: %v", err)
-    }
-
-    // Allow ongoing database operations to complete
-    log.Println("Waiting for database operations to complete...")
-    time.Sleep(5 * time.Second)
-
-    // Close database connections
-    log.Println("Closing database connections...")
-    if err := db.Shutdown(ctx); err != nil {
-        log.Printf("Database shutdown error: %v", err)
-    }
-
-    log.Println("Shutdown complete")
-}
-```
-
-### Circuit Breaker Pattern
-
-```go
-type CircuitBreaker struct {
-    db              *pgxkit.DB
-    failureCount    int64
-    lastFailureTime time.Time
-    state           CircuitState
-    mutex           sync.RWMutex
-}
-
-type CircuitState int
-
-const (
-    StateClosed CircuitState = iota
-    StateOpen
-    StateHalfOpen
-)
-
-func (cb *CircuitBreaker) Execute(ctx context.Context, query string, args ...interface{}) (pgx.Rows, error) {
-    cb.mutex.RLock()
-    state := cb.state
-    cb.mutex.RUnlock()
-
-    switch state {
-    case StateOpen:
-        if time.Since(cb.lastFailureTime) > 60*time.Second {
-            cb.mutex.Lock()
-            cb.state = StateHalfOpen
-            cb.mutex.Unlock()
-        } else {
-            return nil, fmt.Errorf("circuit breaker is open")
-        }
-    case StateHalfOpen:
-        // Allow limited requests through
-    case StateClosed:
-        // Normal operation
-    }
-
-    rows, err := cb.db.Query(ctx, query, args...)
-    if err != nil {
-        cb.recordFailure()
-        return nil, err
-    }
-
-    cb.recordSuccess()
-    return rows, nil
-}
-
-func (cb *CircuitBreaker) recordFailure() {
-    cb.mutex.Lock()
-    defer cb.mutex.Unlock()
-
-    cb.failureCount++
-    cb.lastFailureTime = time.Now()
-
-    if cb.failureCount >= 5 {
-        cb.state = StateOpen
-        log.Println("Circuit breaker opened due to failures")
-    }
-}
-
-func (cb *CircuitBreaker) recordSuccess() {
-    cb.mutex.Lock()
-    defer cb.mutex.Unlock()
-
-    cb.failureCount = 0
-    cb.state = StateClosed
-}
-```
-
-## Error Handling and Recovery
-
-### Production Error Handling
-
-```go
-func setupErrorHandlingDB() *pgxkit.DB {
-    db := pgxkit.NewDB()
-    err := db.Connect(context.Background(), pgxkit.GetDSN(),
-        pgxkit.WithAfterOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-            if operationErr == nil {
-                return nil
-            }
-
-            // Categorize errors
-            switch {
-            case errors.Is(operationErr, pgx.ErrNoRows):
-                // Not found - don't log as error
-                return nil
-
-            case errors.Is(operationErr, context.DeadlineExceeded):
-                // Timeout - critical for monitoring
-                log.Printf("TIMEOUT: Query exceeded deadline: %s", sql)
-                alertManager.SendAlert("Database query timeout", map[string]string{
-                    "query": sql,
-                    "error": operationErr.Error(),
-                })
-
-            case isPgConnectionError(operationErr):
-                // Connection issues - requires immediate attention
-                log.Printf("CONNECTION ERROR: %v", operationErr)
-                alertManager.SendAlert("Database connection error", map[string]string{
-                    "error": operationErr.Error(),
-                })
-
-            default:
-                // Other database errors
-                log.Printf("DATABASE ERROR: %s - %v", sql, operationErr)
-            }
-
-            return nil
-        }),
-    )
-    if err != nil {
-        log.Fatal("Failed to connect:", err)
-    }
-
-    return db
-}
-
-func isPgConnectionError(err error) bool {
-    if err == nil {
-        return false
-    }
-
-    errStr := err.Error()
-    return strings.Contains(errStr, "connection refused") ||
-           strings.Contains(errStr, "connection reset") ||
-           strings.Contains(errStr, "connection timed out")
-}
-```
-
-## Performance Optimization
-
-### Production Query Optimization
-
-```go
-func setupQueryOptimizationDB() *pgxkit.DB {
-    slowQueryThreshold := 500 * time.Millisecond
-
-    db := pgxkit.NewDB()
-    err := db.Connect(context.Background(), pgxkit.GetDSN(),
-        pgxkit.WithAfterOperation(func(ctx context.Context, sql string, args []interface{}, tag pgconn.CommandTag, operationErr error) error {
-            start, ok := ctx.Value("start_time").(time.Time)
-            if !ok {
-                return nil
-            }
-
-            duration := time.Since(start)
-
-            // Log slow queries for optimization
-            if duration > slowQueryThreshold {
-                log.Printf("SLOW QUERY [%v]: %s", duration, sql)
-
-                // Capture query plan for analysis
-                go captureQueryPlan(db, sql, args...)
-            }
-
-            return nil
-        }),
-    )
-    if err != nil {
-        log.Fatal("Failed to connect:", err)
-    }
-
-    return db
-}
-
-func captureQueryPlan(db *pgxkit.DB, sql string, args ...interface{}) {
-    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-    defer cancel()
-
-    explainSQL := "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) " + sql
-    row := db.QueryRow(ctx, explainSQL, args...)
-
-    var planJSON string
-    if err := row.Scan(&planJSON); err != nil {
-        log.Printf("Failed to capture query plan: %v", err)
+    if err := db.HealthCheck(ctx); err != nil {
+        http.Error(w, err.Error(), http.StatusServiceUnavailable)
         return
     }
-
-    // Store or send plan for analysis
-    log.Printf("Query plan captured for: %s", sql)
-}
+    w.WriteHeader(http.StatusOK)
+})
 ```
 
-## Deployment Patterns
+`db.HealthCheck` pings the write pool. For Kubernetes, point both the liveness and readiness probes at this — they're cheap.
 
-### Blue-Green Deployment
+## Graceful shutdown
+
+`db.Shutdown(ctx)` waits for active operations (including in-flight transactions tracked by `BeginTx`), runs `OnShutdown` hooks, then closes the pools. Wire it after your HTTP server shuts down so new requests can't race in.
 
 ```go
-func validateDeployment(db *pgxkit.DB) error {
-    ctx := context.Background()
+sig := make(chan os.Signal, 1)
+signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+<-sig
 
-    // Run deployment validation queries
-    validationQueries := []string{
-        "SELECT 1", // Basic connectivity
-        "SELECT COUNT(*) FROM pg_tables WHERE schemaname = 'public'", // Schema check
-        "SELECT version()", // PostgreSQL version
-    }
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
 
-    for _, query := range validationQueries {
-        var result interface{}
-        if err := db.QueryRow(ctx, query).Scan(&result); err != nil {
-            return fmt.Errorf("validation query failed: %s - %w", query, err)
-        }
-        log.Printf("Validation passed: %s -> %v", query, result)
-    }
-
-    // Test connection pool
-    stats := db.Stats()
-    if stats.TotalConns() == 0 {
-        return fmt.Errorf("no active connections in pool")
-    }
-
-    log.Printf("Deployment validation successful - %d connections active", stats.TotalConns())
-    return nil
-}
+_ = httpServer.Shutdown(ctx)
+_ = db.Shutdown(ctx)
 ```
 
-### Rolling Updates
+## Logging and metrics
+
+Hooks are the integration point for both. See [Examples → Hooks](Examples#hooks) for the full pattern. A minimal observability setup:
 
 ```go
-func rollingUpdateHealthCheck(db *pgxkit.DB) error {
-    // Extended health check for rolling updates
-    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-    defer cancel()
-
-    // Check all critical tables are accessible
-    criticalTables := []string{"users", "orders", "products"}
-
-    for _, table := range criticalTables {
-        var count int64
-        query := fmt.Sprintf("SELECT COUNT(*) FROM %s LIMIT 1", table)
-        if err := db.QueryRow(ctx, query).Scan(&count); err != nil {
-            return fmt.Errorf("critical table %s not accessible: %w", table, err)
+db.Connect(ctx, "",
+    pgxkit.WithAfterOperation(func(ctx context.Context, sql string, _ []interface{}, tag pgconn.CommandTag, err error) error {
+        if err != nil {
+            slog.ErrorContext(ctx, "query failed", "sql", sql, "err", err)
+            metrics.QueryErrors.Inc()
+            return nil
         }
-    }
-
-    // Verify read/write capabilities
-    testID := fmt.Sprintf("health_check_%d", time.Now().Unix())
-
-    // Test write
-    _, err := db.Exec(ctx, "INSERT INTO health_checks (id, timestamp) VALUES ($1, $2) ON CONFLICT (id) DO UPDATE SET timestamp = $2", testID, time.Now())
-    if err != nil {
-        return fmt.Errorf("write test failed: %w", err)
-    }
-
-    // Test read
-    var timestamp time.Time
-    err = db.QueryRow(ctx, "SELECT timestamp FROM health_checks WHERE id = $1", testID).Scan(&timestamp)
-    if err != nil {
-        return fmt.Errorf("read test failed: %w", err)
-    }
-
-    // Cleanup
-    _, _ = db.Exec(ctx, "DELETE FROM health_checks WHERE id = $1", testID)
-
-    return nil
-}
+        if tag.String() != "" {
+            metrics.RowsAffected.Add(float64(tag.RowsAffected()))
+        }
+        return nil
+    }),
+    pgxkit.WithAfterTransaction(func(ctx context.Context, sql string, _ []interface{}, _ pgconn.CommandTag, err error) error {
+        switch sql {
+        case pgxkit.TxCommit:   metrics.TxCommits.Inc()
+        case pgxkit.TxRollback: metrics.TxRollbacks.Inc()
+        }
+        return nil
+    }),
+)
 ```
 
-## Best Practices Summary
+For pool-level metrics, scrape `db.Stats()` periodically (acquired/idle/max counts) and emit gauges.
 
-### Configuration Checklist
+## Errors and retries
 
-- [ ] SSL/TLS enabled and properly configured
-- [ ] Connection pool sized appropriately for load
-- [ ] Environment variables secured and validated
-- [ ] Monitoring and alerting configured
-- [ ] Health checks implemented
-- [ ] Graceful shutdown handling
-- [ ] Error handling and logging
-- [ ] Performance monitoring enabled
-- [ ] Security best practices followed
-- [ ] Backup and recovery procedures tested
+`pgxkit.RetryOperation` and `Retry[T]` retry transient PostgreSQL errors — connection drops, serialization failures (`40001`), deadlocks (`40P01`). Constraint violations and other deterministic errors pass through unchanged so the caller can react.
 
-### Production Monitoring
+```go
+err := pgxkit.RetryOperation(ctx, func(ctx context.Context) error {
+    _, err := db.Exec(ctx, "UPDATE accounts SET balance = balance - $1 WHERE id = $2", amount, id)
+    return err
+}, pgxkit.WithMaxRetries(5))
+```
 
-- [ ] Connection pool utilization
-- [ ] Query performance metrics
-- [ ] Error rates and patterns
-- [ ] SSL connection status
-- [ ] Database replication lag (if applicable)
-- [ ] Resource usage (CPU, memory, I/O)
-- [ ] Alert thresholds configured
-- [ ] Log aggregation and analysis
-- [ ] Performance baseline established
-- [ ] Capacity planning metrics
+For circuit-breaker semantics or richer recovery policies, wrap pgxkit calls in your service layer — pgxkit doesn't ship a circuit breaker.
 
-## See Also
+## Security
 
-- **[Getting Started](Getting-Started)** - Basic setup and configuration
-- **[Performance Guide](Performance-Guide)** - Detailed performance optimization
-- **[Examples](Examples)** - Practical code examples
-- **[Testing Guide](Testing-Guide)** - Testing strategies
-- **[API Reference](API-Reference)** - Complete API documentation
+- Always set `POSTGRES_SSLMODE=require` (or stronger) in production.
+- Pass credentials via env vars or a secret manager; don't bake them into the DSN literal.
+- Limit the database user to the minimum privileges the app needs.
+- Use `pool_max_conn_lifetime` so connections rotate periodically.
+
+## Production checklist
+
+- `WithMaxConns` / `WithMinConns` set to your sized values.
+- `db.HealthCheck` wired to liveness + readiness probes.
+- `db.Shutdown` wired to `SIGTERM`, run after the HTTP server.
+- One `WithAfterOperation` hook recording at least success/error counts and durations.
+- One `WithAfterTransaction` hook recording commit vs rollback.
+- `AssertPlan` baselines for the queries that matter most (CI gate).
+- A retry policy for the writes you can safely retry.
 
 ---
 

--- a/docs/Testing-Guide.md
+++ b/docs/Testing-Guide.md
@@ -1,631 +1,102 @@
-# Testing Best Practices with pgxkit
+# Testing Guide
 
 **[← Back to Home](Home)**
 
-This guide covers effective testing strategies and best practices when using pgxkit in your applications.
+pgxkit ships three things that matter for tests: `RequireDB` (test-database setup with skip), `EnableAssertPlan` / `AssertPlan` (catch query-plan regressions), and `EnableGolden` / `AssertGolden` (catch behavioral changes — extra/missing/reordered statements, different args, commit vs rollback). Everything else — fixture loading, factory patterns, table-driven structure, mocking — is plain Go testing and isn't pgxkit's concern.
 
-## Table of Contents
-
-1. [Testing Philosophy](#testing-philosophy)
-2. [Test Environment Setup](#test-environment-setup)
-3. [Unit Testing](#unit-testing)
-4. [Integration Testing](#integration-testing)
-5. [Plan-Regression Testing](#plan-regression-testing)
-6. [Golden Transcript Testing](#golden-transcript-testing)
-7. [Testing Patterns](#testing-patterns)
-8. [Test Data Management](#test-data-management)
-9. [Performance Testing](#performance-testing)
-10. [Error Testing](#error-testing)
-11. [Best Practices](#best-practices)
-
-## Testing Philosophy
-
-pgxkit follows these testing principles:
-
-- **Test database operations without mocking** - Use real database connections for reliable tests
-- **Isolate test data** - Each test should have its own clean database state
-- **Test performance regressions** - Use plan-regression tests to catch query plan changes
-- **Test error conditions** - Verify proper error handling and recovery
-- **Keep tests fast** - Use efficient setup/teardown and parallel execution
-
-## Test Environment Setup
-
-### Database Configuration
-
-Set up a dedicated test database:
+## Setup
 
 ```bash
-# Test database environment variables
-export TEST_POSTGRES_HOST=localhost
-export TEST_POSTGRES_PORT=5432
-export TEST_POSTGRES_USER=test_user
-export TEST_POSTGRES_PASSWORD=test_password
-export TEST_POSTGRES_DB=test_db
-export TEST_POSTGRES_SSLMODE=disable
+export TEST_DATABASE_URL=postgres://user:pass@localhost:5432/test?sslmode=disable
 ```
 
-### Test Database Initialization
+`RequireDB` skips the test if `TEST_DATABASE_URL` is unset, otherwise returns a connected `*pgxkit.TestDB`:
 
 ```go
-package main
-
-import (
-    "context"
-    "testing"
-
-    "github.com/nhalm/pgxkit"
-)
-
-func setupTestDB(t *testing.T) *pgxkit.TestDB {
-    // Create test database connection
-    testDB := pgxkit.NewTestDB()
-
-    // Connect to test database (uses TEST_DATABASE_URL env var)
-    ctx := context.Background()
-    err := testDB.Connect(ctx, "")
-    if err != nil {
-        t.Skip("Test database not available:", err)
-    }
-
-    // Setup database schema and initial data
-    err = testDB.Setup()
-    if err != nil {
-        t.Skip("Test database setup failed:", err)
-    }
-
-    // Clean up after test
-    t.Cleanup(func() {
-        testDB.Clean()
-        testDB.Shutdown(ctx)
-    })
-
-    return testDB
+func TestThing(t *testing.T) {
+    testDB := pgxkit.RequireDB(t)
+    // ... use testDB.DB ...
 }
 ```
 
-### Test Suite Structure
+Don't build your own `TestSuite` wrapper or `setupTestDB` helper — `RequireDB` plus `t.Cleanup` covers it. If you need shared setup across tests, do it in `TestMain`.
+
+## Plan-regression testing
+
+`EnableAssertPlan` returns a fresh `*DB` that captures `EXPLAIN (FORMAT JSON, COSTS OFF)` for every SELECT/INSERT/UPDATE/DELETE/WITH it sees. `AssertPlan` writes the baseline on first run, diffs against it on later runs.
 
 ```go
-// test_helper.go
-package myapp
+func TestUserSummary_Plan(t *testing.T) {
+    testDB := pgxkit.RequireDB(t)
+    db := testDB.EnableAssertPlan("TestUserSummary")
 
-import (
-    "context"
-    "testing"
-
-    "github.com/nhalm/pgxkit"
-)
-
-// TestSuite provides common test utilities
-type TestSuite struct {
-    DB  *pgxkit.TestDB
-    ctx context.Context
-}
-
-func NewTestSuite(t *testing.T) *TestSuite {
-    return &TestSuite{
-        DB:  setupTestDB(t),
-        ctx: context.Background(),
-    }
-}
-
-// loadFixtureSQL executes SQL from a file for test data setup.
-// Implement your own fixture loading logic based on your project needs.
-func (ts *TestSuite) loadFixtureSQL(t *testing.T, sql string) {
-    _, err := ts.DB.Exec(ts.ctx, sql)
-    if err != nil {
-        t.Fatalf("Failed to execute fixture SQL: %v", err)
-    }
-}
-
-func (ts *TestSuite) AssertRowCount(t *testing.T, table string, expected int) {
-    var count int
-    err := ts.DB.QueryRow(ts.ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&count)
-    if err != nil {
-        t.Fatalf("Failed to count rows in %s: %v", table, err)
-    }
-
-    if count != expected {
-        t.Errorf("Expected %d rows in %s, got %d", expected, table, count)
-    }
-}
-```
-
-## Unit Testing
-
-### Repository Testing
-
-```go
-func TestUserRepository_CreateUser(t *testing.T) {
-    suite := NewTestSuite(t)
-    repo := NewUserRepository(suite.DB)
-
-    user := &User{
-        Name:  "John Doe",
-        Email: "john@example.com",
-    }
-
-    // Test user creation
-    err := repo.CreateUser(suite.ctx, user)
-    require.NoError(t, err)
-    require.NotZero(t, user.ID)
-
-    // Verify user was created
-    retrieved, err := repo.GetUser(suite.ctx, user.ID)
-    require.NoError(t, err)
-    assert.Equal(t, user.Name, retrieved.Name)
-    assert.Equal(t, user.Email, retrieved.Email)
-}
-
-func TestUserRepository_GetUser_NotFound(t *testing.T) {
-    suite := NewTestSuite(t)
-    repo := NewUserRepository(suite.DB)
-
-    // Test getting non-existent user
-    _, err := repo.GetUser(suite.ctx, 999)
-    assert.Error(t, err)
-    assert.True(t, errors.Is(err, pgx.ErrNoRows))
-}
-
-func TestUserRepository_UpdateUser(t *testing.T) {
-    suite := NewTestSuite(t)
-    repo := NewUserRepository(suite.DB)
-
-    // Create test data directly with SQL
-    _, err := suite.DB.Exec(suite.ctx, `
-        INSERT INTO users (id, name, email) VALUES (1, 'Original Name', 'original@example.com')
-        ON CONFLICT (id) DO NOTHING
+    rows, err := db.Query(ctx, `
+        SELECT u.id, u.name, COUNT(o.id), COALESCE(SUM(o.total), 0)
+        FROM users u LEFT JOIN orders o ON u.id = o.user_id
+        WHERE u.active = true
+        GROUP BY u.id, u.name
+        ORDER BY 4 DESC
+        LIMIT 10
     `)
     require.NoError(t, err)
+    rows.Close()
 
-    // Update existing user
-    user := &User{
-        ID:    1,
-        Name:  "Updated Name",
-        Email: "updated@example.com",
-    }
-
-    err = repo.UpdateUser(suite.ctx, user)
-    require.NoError(t, err)
-
-    // Verify update
-    retrieved, err := repo.GetUser(suite.ctx, 1)
-    require.NoError(t, err)
-    assert.Equal(t, user.Name, retrieved.Name)
-    assert.Equal(t, user.Email, retrieved.Email)
+    db.AssertPlan(t, "TestUserSummary")
 }
 ```
 
-### Service Layer Testing
+Baselines live at `testdata/plans/<name>.json`. A plan-shape change — index-scan replaced by seq-scan, hash-join replaced by nested-loop, an extra sort node, a different join order — fails the test with a unified diff. Plan capture uses `EXPLAIN` without `ANALYZE`, so the underlying statement isn't executed and there are no side effects to clean up.
 
-```go
-func TestUserService_CreateUser(t *testing.T) {
-    suite := NewTestSuite(t)
-    service := NewUserService(suite.DB)
+Refresh after intentional changes: `go test -overwrite-plan`.
 
-    tests := []struct {
-        name    string
-        input   CreateUserRequest
-        wantErr bool
-        errMsg  string
-    }{
-        {
-            name: "valid user",
-            input: CreateUserRequest{
-                Name:  "John Doe",
-                Email: "john@example.com",
-            },
-            wantErr: false,
-        },
-        {
-            name: "duplicate email",
-            input: CreateUserRequest{
-                Name:  "Jane Doe",
-                Email: "john@example.com", // Same email as above
-            },
-            wantErr: true,
-            errMsg:  "email already exists",
-        },
-        {
-            name: "invalid email",
-            input: CreateUserRequest{
-                Name:  "Invalid User",
-                Email: "not-an-email",
-            },
-            wantErr: true,
-            errMsg:  "invalid email format",
-        },
-    }
+`AssertPlan` does not compare result rows or measure execution time. Assert those in the test body if you need to.
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            user, err := service.CreateUser(suite.ctx, tt.input)
+## Golden transcript testing
 
-            if tt.wantErr {
-                assert.Error(t, err)
-                if tt.errMsg != "" {
-                    assert.Contains(t, err.Error(), tt.errMsg)
-                }
-                assert.Nil(t, user)
-            } else {
-                assert.NoError(t, err)
-                assert.NotNil(t, user)
-                assert.NotZero(t, user.ID)
-                assert.Equal(t, tt.input.Name, user.Name)
-                assert.Equal(t, tt.input.Email, user.Email)
-            }
-        })
-    }
-}
-```
-
-## Integration Testing
-
-### API Endpoint Testing
-
-```go
-func TestUserHandler_CreateUser(t *testing.T) {
-    suite := NewTestSuite(t)
-    handler := NewUserHandler(suite.DB)
-
-    tests := []struct {
-        name           string
-        requestBody    string
-        expectedStatus int
-        checkResponse  func(t *testing.T, resp *http.Response, body []byte)
-    }{
-        {
-            name: "successful creation",
-            requestBody: `{
-                "name": "John Doe",
-                "email": "john@example.com"
-            }`,
-            expectedStatus: http.StatusCreated,
-            checkResponse: func(t *testing.T, resp *http.Response, body []byte) {
-                var user User
-                err := json.Unmarshal(body, &user)
-                require.NoError(t, err)
-                assert.NotZero(t, user.ID)
-                assert.Equal(t, "John Doe", user.Name)
-                assert.Equal(t, "john@example.com", user.Email)
-            },
-        },
-        {
-            name: "invalid json",
-            requestBody: `{
-                "name": "John Doe",
-                "email":
-            }`,
-            expectedStatus: http.StatusBadRequest,
-            checkResponse: func(t *testing.T, resp *http.Response, body []byte) {
-                assert.Contains(t, string(body), "invalid JSON")
-            },
-        },
-    }
-
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            req := httptest.NewRequest(http.MethodPost, "/users",
-                strings.NewReader(tt.requestBody))
-            req.Header.Set("Content-Type", "application/json")
-
-            w := httptest.NewRecorder()
-            handler.CreateUser(w, req)
-
-            resp := w.Result()
-            body, err := io.ReadAll(resp.Body)
-            require.NoError(t, err)
-
-            assert.Equal(t, tt.expectedStatus, resp.StatusCode)
-
-            if tt.checkResponse != nil {
-                tt.checkResponse(t, resp, body)
-            }
-        })
-    }
-}
-```
-
-### Transaction Testing
-
-```go
-func TestUserService_CreateUserWithProfile(t *testing.T) {
-    suite := NewTestSuite(t)
-    service := NewUserService(suite.DB)
-
-    t.Run("successful transaction", func(t *testing.T) {
-        req := CreateUserWithProfileRequest{
-            User: CreateUserRequest{
-                Name:  "John Doe",
-                Email: "john@example.com",
-            },
-            Profile: CreateProfileRequest{
-                Bio:    "Software developer",
-                Avatar: "https://example.com/avatar.jpg",
-            },
-        }
-
-        result, err := service.CreateUserWithProfile(suite.ctx, req)
-        require.NoError(t, err)
-
-        // Verify user was created
-        user, err := service.GetUser(suite.ctx, result.UserID)
-        require.NoError(t, err)
-        assert.Equal(t, req.User.Name, user.Name)
-
-        // Verify profile was created
-        profile, err := service.GetProfile(suite.ctx, result.UserID)
-        require.NoError(t, err)
-        assert.Equal(t, req.Profile.Bio, profile.Bio)
-    })
-
-    t.Run("transaction rollback on error", func(t *testing.T) {
-        // Create user first to cause duplicate email error
-        _, err := suite.DB.Exec(suite.ctx, `
-            INSERT INTO users (id, name, email, active) VALUES
-            (100, 'Existing User', 'existing@example.com', true)
-            ON CONFLICT (id) DO NOTHING
-        `)
-        require.NoError(t, err)
-
-        req := CreateUserWithProfileRequest{
-            User: CreateUserRequest{
-                Name:  "Jane Doe",
-                Email: "existing@example.com", // Already exists
-            },
-            Profile: CreateProfileRequest{
-                Bio: "Should not be created",
-            },
-        }
-
-        _, err = service.CreateUserWithProfile(suite.ctx, req)
-        require.Error(t, err)
-
-        // Verify no partial data was created
-        suite.AssertRowCount(t, "users", 1)    // Only fixture user
-        suite.AssertRowCount(t, "profiles", 0) // No profiles created
-    })
-}
-```
-
-## Plan-Regression Testing
-
-Plan-regression testing captures the structural query plan via `EXPLAIN (FORMAT JSON, COSTS OFF)` and asserts it is unchanged across runs. It catches plan shape changes such as seq-scan to index-scan, nested-loop to hash-join, a new sort node, or a different join order. It does NOT assert anything about query result rows — assert those yourself in the test body. Because the captured form is plan-only (no `ANALYZE`), the underlying statement is not executed during plan capture, so there are no side effects.
-
-### Query Plan Testing
-
-```go
-func TestUserQueries_Plan(t *testing.T) {
-    testDB := setupTestDB(t)
-
-    // Enable plan-regression testing
-    db := testDB.EnableAssertPlan("TestUserQueries_Plan")
-
-    // Load test data with manual SQL
-    _, err := testDB.Exec(context.Background(), `
-        INSERT INTO users (id, name, email, active) VALUES
-        (1, 'John Doe', 'john@example.com', true),
-        (2, 'Jane Smith', 'jane@example.com', true),
-        (3, 'Bob Johnson', 'bob@example.com', false)
-        ON CONFLICT (id) DO NOTHING;
-
-        INSERT INTO orders (id, user_id, total, created_at) VALUES
-        (1, 1, 99.99, NOW() - INTERVAL '3 days'),
-        (2, 1, 149.99, NOW() - INTERVAL '2 days'),
-        (3, 2, 75.50, NOW() - INTERVAL '1 day')
-        ON CONFLICT (id) DO NOTHING;
-    `)
-    require.NoError(t, err)
-
-    t.Run("complex_user_query", func(t *testing.T) {
-        // This query's structural EXPLAIN plan will be captured and asserted
-        rows, err := db.Query(context.Background(), `
-            SELECT
-                u.id,
-                u.name,
-                u.email,
-                COUNT(o.id) as order_count,
-                COALESCE(SUM(o.total), 0) as total_spent
-            FROM users u
-            LEFT JOIN orders o ON u.id = o.user_id
-            WHERE u.active = true
-            GROUP BY u.id, u.name, u.email
-            HAVING COUNT(o.id) > 0
-            ORDER BY total_spent DESC
-            LIMIT 10
-        `)
-        require.NoError(t, err)
-        defer rows.Close()
-
-        var users []UserSummary
-        for rows.Next() {
-            var user UserSummary
-            err := rows.Scan(&user.ID, &user.Name, &user.Email,
-                &user.OrderCount, &user.TotalSpent)
-            require.NoError(t, err)
-            users = append(users, user)
-        }
-
-        // Verify results make sense
-        require.True(t, len(users) > 0)
-
-        // The plan-regression test asserts the structural query plan is
-        // unchanged. It does not compare result rows or measure execution
-        // time - assert results yourself if needed.
-    })
-
-    t.Run("user_search_query", func(t *testing.T) {
-        // Test search functionality
-        rows, err := db.Query(context.Background(), `
-            SELECT id, name, email
-            FROM users
-            WHERE
-                active = true AND
-                (name ILIKE $1 OR email ILIKE $1)
-            ORDER BY name
-            LIMIT 20
-        `, "%john%")
-        require.NoError(t, err)
-        defer rows.Close()
-
-        var users []User
-        for rows.Next() {
-            var user User
-            err := rows.Scan(&user.ID, &user.Name, &user.Email)
-            require.NoError(t, err)
-            users = append(users, user)
-        }
-
-        // The plan-regression test will assert the structural plan of this search is unchanged
-        assert.True(t, len(users) >= 0)
-    })
-
-    t.Run("insert_with_returning", func(t *testing.T) {
-        // DML queries are also captured. EXPLAIN without ANALYZE plans the
-        // statement without executing it, so plan capture has no side effects.
-        var userID int
-        err := db.QueryRow(context.Background(), `
-            INSERT INTO users (name, email, active)
-            VALUES ($1, $2, true)
-            RETURNING id
-        `, "Test User", "test@example.com").Scan(&userID)
-        require.NoError(t, err)
-    })
-
-    t.Run("update_query", func(t *testing.T) {
-        // UPDATE query plans are captured
-        _, err := db.Exec(context.Background(), `
-            UPDATE users
-            SET last_login = NOW()
-            WHERE active = true AND last_login < NOW() - INTERVAL '30 days'
-        `)
-        require.NoError(t, err)
-    })
-
-    db.AssertPlan(t, "TestUserQueries_Plan")
-}
-```
-
-### Performance Regression Testing
-
-```go
-func TestPerformanceRegression(t *testing.T) {
-    testDB := setupTestDB(t)
-    db := testDB.EnableAssertPlan("TestPerformanceRegression")
-
-    // Create large dataset for performance testing
-    _, err := testDB.Exec(context.Background(), `
-        INSERT INTO users (name, email, active, created_at)
-        SELECT
-            'User ' || i,
-            'user' || i || '@example.com',
-            true,
-            NOW() - (i || ' minutes')::interval
-        FROM generate_series(1, 10000) AS i
-        ON CONFLICT DO NOTHING
-    `)
-    require.NoError(t, err)
-
-    t.Run("pagination_performance", func(t *testing.T) {
-        start := time.Now()
-
-        rows, err := db.Query(context.Background(), `
-            SELECT id, name, email, created_at
-            FROM users
-            WHERE active = true
-            ORDER BY created_at DESC
-            LIMIT 50 OFFSET 1000
-        `)
-        require.NoError(t, err)
-        defer rows.Close()
-
-        var users []User
-        for rows.Next() {
-            var user User
-            err := rows.Scan(&user.ID, &user.Name, &user.Email, &user.CreatedAt)
-            require.NoError(t, err)
-            users = append(users, user)
-        }
-
-        duration := time.Since(start)
-
-        // Assert reasonable performance
-        assert.True(t, duration < 100*time.Millisecond,
-            "Query took too long: %v", duration)
-        assert.Len(t, users, 50)
-
-        // The plan-regression test will track:
-        // - Structural EXPLAIN plan (FORMAT JSON, COSTS OFF)
-        // - Plan-shape changes such as seq-scan vs index-scan,
-        //   nested-loop vs hash-join, new sort nodes, or join-order changes
-        //
-        // Wall-clock duration is asserted explicitly above; the
-        // plan-regression test does not measure execution time.
-    })
-
-    db.AssertPlan(t, "TestPerformanceRegression")
-}
-```
-
-## Golden Transcript Testing
-
-Golden transcript testing is a behavioral assertion: it captures the full sequence of database events a scenario produces — `BEGIN`, every `Query`/`Exec` with its SQL, normalized args, and materialized result rows, and the closing `COMMIT` or `ROLLBACK` — and asserts on subsequent runs that the transcript hasn't changed. It catches an extra UPDATE, a missing INSERT, a different argument, a different returned row, or a `COMMIT` becoming a `ROLLBACK`.
-
-This complements [Plan-Regression Testing](#plan-regression-testing): plan-regression catches changes to query plan *shape*, golden transcripts catch changes to *behavior*. Use one or the other per scenario — `EnableGolden` and `EnableAssertPlan` each return a fresh `*DB`, so they don't compose on the same instance.
-
-### Basic Usage
+`EnableGolden` returns a `*DB` that records every database event for the scenario. `AssertGolden` writes the baseline on first run, diffs on later runs.
 
 ```go
 func TestCreateOrder(t *testing.T) {
     testDB := pgxkit.RequireDB(t)
-
     golden := testDB.EnableGolden("TestCreateOrder")
 
-    // run the code under test using golden as the DB
-    _, err := golden.Exec(context.Background(),
-        "INSERT INTO orders (total) VALUES ($1)", 100)
+    tx, err := golden.BeginTx(ctx, pgx.TxOptions{})
     require.NoError(t, err)
+    var orderID int
+    require.NoError(t, tx.QueryRow(ctx,
+        "INSERT INTO orders (total) VALUES ($1) RETURNING id", 100,
+    ).Scan(&orderID))
+    _, err = tx.Exec(ctx,
+        "INSERT INTO order_items (order_id, sku, qty) VALUES ($1, $2, $3)",
+        orderID, "SKU-1", 2)
+    require.NoError(t, err)
+    require.NoError(t, tx.Commit(ctx))
 
     golden.AssertGolden(t, "TestCreateOrder")
 }
 ```
 
-On the first run, the test writes `testdata/golden/TestCreateOrder.json` and logs that a baseline was created. On subsequent runs, it compares the recorded transcript against that file and fails with a unified diff on any mismatch.
+### What the transcript captures
 
-### What the Transcript Captures
-
-Every event pgxkit observes ends up in the transcript, in order:
+In order:
 
 - `BEGIN`, `COMMIT`, `ROLLBACK` for transactions started via `BeginTx`.
-- `QUERY` events for every `Query`, `QueryRow`, and `Exec` call — including DDL (`CREATE TABLE`, `ALTER`, etc.) and `SET` statements. There is no SQL-prefix filter.
-- For `Query` and `QueryRow`, materialized result rows as `column → value` maps.
-- For `Exec`, the `rows_affected` integer from the command tag.
+- `QUERY` events for every `Query`, `QueryRow`, and `Exec` — including DDL and `SET`. No SQL-prefix filter.
+- The SQL string and normalized args.
+- `rows_affected` for `Exec` (taken from the `pgconn.CommandTag`). Not present for `Query` / `QueryRow`.
 
-Caller iteration of `pgx.Rows` still works normally — pgxkit reads the rows once for the transcript, then replays them through a wrapper.
+The transcript catches: an extra UPDATE, a missing INSERT, a different argument, a `COMMIT` that became a `ROLLBACK`, a reordering of statements. It does **not** capture result rows — for "did this row change" assertions, scan and assert in the test body or use `AssertPlan` for plan-shape stability.
 
-### Refreshing the Baseline
+### Normalization
 
-When you intentionally change behavior (a new column in a returning clause, an extra normalization step, a deliberate query reorder), regenerate the baseline:
+To keep transcripts stable across runs:
 
-```bash
-go test -overwrite-golden -run TestCreateOrder
-```
+- `time.Time` (and `*time.Time`) → `"<TIMESTAMP>"`.
+- UUIDs (`uuid.UUID`, `[16]byte`, canonical UUID strings) → `"<UUID:1>"`, `"<UUID:2>"`, ... assigned in first-seen order so the same UUID gets the same placeholder wherever it appears.
 
-The flag is package-scoped on pgxkit, so any test binary that links pgxkit accepts it.
+Args have no column hint and pass through other types unchanged.
 
-### Normalization Defaults
-
-To keep transcripts stable across runs, volatile values are replaced with placeholders before the transcript is written or compared:
-
-- `time.Time` values → `"<TIMESTAMP>"`.
-- UUIDs (`uuid.UUID`, `[16]byte`, or canonical UUID strings) → `"<UUID:1>"`, `"<UUID:2>"`, ... assigned in first-seen order, so the same UUID gets the same placeholder wherever it appears.
-- Integer columns whose name is `id` or ends in `_id` → `"<ID:1>"`, `"<ID:2>"`, ... also first-seen by numeric value (so `id=7` and `user_id=7` collapse to the same placeholder).
-
-Args have no column hint, so integer normalization does not trigger there; timestamps and UUIDs do.
-
-### Custom Normalization
-
-Add domain-specific normalizers via `WithGoldenNormalizer`. Custom normalizers run **before** defaults, so you can override `time.Time` handling, redact sensitive fields, or canonicalize ordering of map-shaped values:
+### Custom normalization
 
 ```go
 golden := testDB.EnableGolden("TestCreateOrder",
@@ -638,561 +109,44 @@ golden := testDB.EnableGolden("TestCreateOrder",
 )
 ```
 
-Return `(replacement, true)` to take over normalization for the value, or `(nil, false)` to fall through to the next custom normalizer or to the defaults.
+Custom normalizers run before the defaults. Return `(replacement, true)` to take over normalization; `(nil, false)` to fall through.
 
-## Testing Patterns
+### Refreshing the baseline
 
-### Table-Driven Tests
+`go test -overwrite-golden` regenerates baselines for any test it runs. Use it after intentional behavior changes (new column in a `RETURNING` clause, deliberate statement reorder, etc.).
 
-```go
-func TestUserValidation(t *testing.T) {
-    tests := []struct {
-        name    string
-        user    User
-        wantErr bool
-        errMsg  string
-    }{
-        {
-            name: "valid user",
-            user: User{
-                Name:  "John Doe",
-                Email: "john@example.com",
-            },
-            wantErr: false,
-        },
-        {
-            name: "empty name",
-            user: User{
-                Name:  "",
-                Email: "john@example.com",
-            },
-            wantErr: true,
-            errMsg:  "name is required",
-        },
-        {
-            name: "invalid email",
-            user: User{
-                Name:  "John Doe",
-                Email: "not-an-email",
-            },
-            wantErr: true,
-            errMsg:  "invalid email",
-        },
-        {
-            name: "email too long",
-            user: User{
-                Name:  "John Doe",
-                Email: strings.Repeat("a", 250) + "@example.com",
-            },
-            wantErr: true,
-            errMsg:  "email too long",
-        },
-    }
+## Plan vs golden — which to use
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            err := ValidateUser(&tt.user)
+They answer different questions and don't compose on a single `*DB`.
 
-            if tt.wantErr {
-                assert.Error(t, err)
-                if tt.errMsg != "" {
-                    assert.Contains(t, err.Error(), tt.errMsg)
-                }
-            } else {
-                assert.NoError(t, err)
-            }
-        })
-    }
-}
-```
+- **`AssertPlan`** — query-plan shape. Catches missing indexes, accidental seq-scans, join-order changes from migrations.
+- **`AssertGolden`** — behavioral sequence. Catches an extra UPDATE the refactor introduced, an INSERT that's now missing, a `COMMIT` that became a `ROLLBACK`.
 
-### Parallel Testing
+Pick per scenario.
+
+## Transactions in tests
+
+`db.BeginTx` returns a `*pgxkit.Tx` that fires the same hooks as the parent DB. The "defer Rollback() + explicit Commit()" pattern is safe — atomic finalization makes the rollback a no-op once Commit succeeds.
 
 ```go
-func TestUserRepository_Parallel(t *testing.T) {
-    t.Run("parallel_operations", func(t *testing.T) {
-        tests := []struct {
-            name string
-            test func(t *testing.T)
-        }{
-            {
-                name: "create_user",
-                test: func(t *testing.T) {
-                    suite := NewTestSuite(t)
-                    repo := NewUserRepository(suite.DB)
-
-                    user := &User{
-                        Name:  "Parallel User 1",
-                        Email: "parallel1@example.com",
-                    }
-
-                    err := repo.CreateUser(suite.ctx, user)
-                    require.NoError(t, err)
-                },
-            },
-            {
-                name: "query_users",
-                test: func(t *testing.T) {
-                    suite := NewTestSuite(t)
-                    repo := NewUserRepository(suite.DB)
-
-                    // Set up test data
-                    _, err := suite.DB.Exec(suite.ctx, `
-                        INSERT INTO users (name, email, active) VALUES
-                        ('Test User', 'test@example.com', true)
-                        ON CONFLICT DO NOTHING
-                    `)
-                    require.NoError(t, err)
-
-                    users, err := repo.GetAllUsers(suite.ctx)
-                    require.NoError(t, err)
-                    assert.True(t, len(users) > 0)
-                },
-            },
-        }
-
-        for _, tt := range tests {
-            tt := tt // Capture loop variable
-            t.Run(tt.name, func(t *testing.T) {
-                t.Parallel() // Run tests in parallel
-                tt.test(t)
-            })
-        }
-    })
-}
+tx, err := db.BeginTx(ctx, pgx.TxOptions{})
+require.NoError(t, err)
+defer tx.Rollback(ctx)
+// ... operations ...
+require.NoError(t, tx.Commit(ctx))
 ```
 
-## Test Data Management
+## Errors
 
-### Fixture Files
-
-Store SQL fixtures in your project and load them manually:
-
-```sql
--- fixtures/users.sql
-INSERT INTO users (id, name, email, active, created_at) VALUES
-(1, 'John Doe', 'john@example.com', true, NOW() - INTERVAL '10 days'),
-(2, 'Jane Smith', 'jane@example.com', true, NOW() - INTERVAL '9 days'),
-(3, 'Bob Johnson', 'bob@example.com', false, NOW() - INTERVAL '8 days')
-ON CONFLICT (id) DO UPDATE SET
-    name = EXCLUDED.name,
-    email = EXCLUDED.email,
-    active = EXCLUDED.active;
-
--- fixtures/orders.sql
-INSERT INTO orders (id, user_id, total, created_at) VALUES
-(1, 1, 99.99, NOW() - INTERVAL '3 days'),
-(2, 1, 149.99, NOW() - INTERVAL '2 days'),
-(3, 2, 75.50, NOW() - INTERVAL '1 day')
-ON CONFLICT (id) DO UPDATE SET
-    user_id = EXCLUDED.user_id,
-    total = EXCLUDED.total;
-```
+Use `errors.Is` for `pgx.ErrNoRows`. For PostgreSQL constraint codes, use `errors.As` with `*pgconn.PgError`:
 
 ```go
-// Helper to load fixture files
-func loadFixture(t *testing.T, db *pgxkit.TestDB, filename string) {
-    ctx := context.Background()
-    data, err := os.ReadFile(filepath.Join("fixtures", filename))
-    if err != nil {
-        t.Fatalf("Failed to read fixture %s: %v", filename, err)
-    }
-
-    _, err = db.Exec(ctx, string(data))
-    if err != nil {
-        t.Fatalf("Failed to execute fixture %s: %v", filename, err)
-    }
-}
-
-// Test with fixtures
-func TestOrderRepository_GetUserOrders(t *testing.T) {
-    suite := NewTestSuite(t)
-    loadFixture(t, suite.DB, "users.sql")
-    loadFixture(t, suite.DB, "orders.sql")
-    repo := NewOrderRepository(suite.DB)
-
-    orders, err := repo.GetUserOrders(suite.ctx, 1)
-    require.NoError(t, err)
-    assert.Len(t, orders, 2) // User 1 has 2 orders
-
-    // Verify order details
-    assert.Equal(t, 99.99, orders[0].Total)
-    assert.Equal(t, 149.99, orders[1].Total)
+var pgErr *pgconn.PgError
+if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+    // unique violation
 }
 ```
-
-### Factory Pattern
-
-```go
-type UserFactory struct {
-    db *pgxkit.TestDB
-}
-
-func NewUserFactory(db *pgxkit.TestDB) *UserFactory {
-    return &UserFactory{db: db}
-}
-
-func (f *UserFactory) Create(ctx context.Context, overrides ...func(*User)) *User {
-    user := &User{
-        Name:   "Test User",
-        Email:  fmt.Sprintf("test%d@example.com", time.Now().UnixNano()),
-        Active: true,
-    }
-
-    // Apply overrides
-    for _, override := range overrides {
-        override(user)
-    }
-
-    // Save to database
-    err := f.db.QueryRow(ctx, `
-        INSERT INTO users (name, email, active)
-        VALUES ($1, $2, $3)
-        RETURNING id, created_at
-    `, user.Name, user.Email, user.Active).Scan(&user.ID, &user.CreatedAt)
-
-    if err != nil {
-        panic(fmt.Sprintf("Failed to create test user: %v", err))
-    }
-
-    return user
-}
-
-// Usage in tests
-func TestUserService_UpdateUser(t *testing.T) {
-    suite := NewTestSuite(t)
-    factory := NewUserFactory(suite.DB)
-    service := NewUserService(suite.DB)
-
-    // Create test user with specific attributes
-    user := factory.Create(suite.ctx, func(u *User) {
-        u.Name = "Original Name"
-        u.Email = "original@example.com"
-    })
-
-    // Test update
-    user.Name = "Updated Name"
-    err := service.UpdateUser(suite.ctx, user)
-    require.NoError(t, err)
-
-    // Verify update
-    updated, err := service.GetUser(suite.ctx, user.ID)
-    require.NoError(t, err)
-    assert.Equal(t, "Updated Name", updated.Name)
-}
-```
-
-## Performance Testing
-
-### Benchmark Tests
-
-```go
-func BenchmarkUserRepository_GetUser(b *testing.B) {
-    testDB := setupBenchmarkDB(b)
-    repo := NewUserRepository(testDB)
-    ctx := context.Background()
-
-    // Create test user
-    user := &User{
-        Name:  "Benchmark User",
-        Email: "benchmark@example.com",
-    }
-    err := repo.CreateUser(ctx, user)
-    if err != nil {
-        b.Fatal(err)
-    }
-
-    b.ResetTimer()
-    b.RunParallel(func(pb *testing.PB) {
-        for pb.Next() {
-            _, err := repo.GetUser(ctx, user.ID)
-            if err != nil {
-                b.Error(err)
-            }
-        }
-    })
-}
-
-func BenchmarkUserRepository_CreateUser(b *testing.B) {
-    testDB := setupBenchmarkDB(b)
-    repo := NewUserRepository(testDB)
-    ctx := context.Background()
-
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        user := &User{
-            Name:  fmt.Sprintf("User %d", i),
-            Email: fmt.Sprintf("user%d@example.com", i),
-        }
-
-        err := repo.CreateUser(ctx, user)
-        if err != nil {
-            b.Fatal(err)
-        }
-    }
-}
-
-func setupBenchmarkDB(b *testing.B) *pgxkit.TestDB {
-    testDB := pgxkit.NewTestDB()
-    ctx := context.Background()
-    err := testDB.Connect(ctx, "")
-    if err != nil {
-        b.Skip("Test database not available:", err)
-    }
-
-    err = testDB.Setup()
-    if err != nil {
-        b.Skip("Test database setup failed:", err)
-    }
-
-    b.Cleanup(func() {
-        testDB.Clean()
-        testDB.Shutdown(ctx)
-    })
-
-    return testDB
-}
-```
-
-### Load Testing
-
-```go
-func TestConcurrentUserCreation(t *testing.T) {
-    suite := NewTestSuite(t)
-    service := NewUserService(suite.DB)
-
-    const numUsers = 100
-    const numWorkers = 10
-
-    userChan := make(chan CreateUserRequest, numUsers)
-    resultChan := make(chan error, numUsers)
-
-    // Start workers
-    for i := 0; i < numWorkers; i++ {
-        go func() {
-            for req := range userChan {
-                _, err := service.CreateUser(suite.ctx, req)
-                resultChan <- err
-            }
-        }()
-    }
-
-    // Send work
-    go func() {
-        defer close(userChan)
-        for i := 0; i < numUsers; i++ {
-            userChan <- CreateUserRequest{
-                Name:  fmt.Sprintf("User %d", i),
-                Email: fmt.Sprintf("user%d@example.com", i),
-            }
-        }
-    }()
-
-    // Collect results
-    var errors []error
-    for i := 0; i < numUsers; i++ {
-        if err := <-resultChan; err != nil {
-            errors = append(errors, err)
-        }
-    }
-
-    // Verify results
-    if len(errors) > 0 {
-        t.Errorf("Got %d errors out of %d operations: %v",
-            len(errors), numUsers, errors[0])
-    }
-
-    // Verify all users were created
-    suite.AssertRowCount(t, "users", numUsers)
-}
-```
-
-## Error Testing
-
-### Connection Error Testing
-
-```go
-func TestDatabaseConnection_Errors(t *testing.T) {
-    t.Run("connection_timeout", func(t *testing.T) {
-        // Use invalid host to trigger timeout
-        dsn := "postgres://user:pass@invalid-host:5432/db?connect_timeout=1"
-
-        db := pgxkit.NewDB()
-        err := db.Connect(context.Background(), dsn)
-
-        assert.Error(t, err)
-        assert.Contains(t, err.Error(), "connection")
-    })
-
-    t.Run("invalid_credentials", func(t *testing.T) {
-        dsn := "postgres://invalid:invalid@localhost:5432/testdb"
-
-        db := pgxkit.NewDB()
-        err := db.Connect(context.Background(), dsn)
-
-        assert.Error(t, err)
-        // Don't check specific error message as it varies
-    })
-
-    t.Run("database_not_found", func(t *testing.T) {
-        dsn := "postgres://user:pass@localhost:5432/nonexistent_db"
-
-        db := pgxkit.NewDB()
-        err := db.Connect(context.Background(), dsn)
-
-        assert.Error(t, err)
-    })
-}
-```
-
-### Query Error Testing
-
-```go
-func TestRepository_QueryErrors(t *testing.T) {
-    suite := NewTestSuite(t)
-    repo := NewUserRepository(suite.DB)
-
-    t.Run("syntax_error", func(t *testing.T) {
-        // Intentional SQL syntax error
-        _, err := suite.DB.Query(suite.ctx, "SELECT * FORM users") // FORM instead of FROM
-        assert.Error(t, err)
-        assert.Contains(t, err.Error(), "syntax")
-    })
-
-    t.Run("constraint_violation", func(t *testing.T) {
-        // Create user with unique email constraint violation
-        user1 := &User{
-            Name:  "User 1",
-            Email: "duplicate@example.com",
-        }
-        err := repo.CreateUser(suite.ctx, user1)
-        require.NoError(t, err)
-
-        // Try to create another user with same email
-        user2 := &User{
-            Name:  "User 2",
-            Email: "duplicate@example.com",
-        }
-        err = repo.CreateUser(suite.ctx, user2)
-        assert.Error(t, err)
-        assert.Contains(t, err.Error(), "duplicate")
-    })
-
-    t.Run("not_found", func(t *testing.T) {
-        _, err := repo.GetUser(suite.ctx, 999999)
-        assert.Error(t, err)
-        assert.True(t, errors.Is(err, pgx.ErrNoRows))
-    })
-}
-```
-
-## Best Practices
-
-### Test Organization
-
-```go
-// Group related tests
-func TestUserRepository(t *testing.T) {
-    t.Run("CreateUser", func(t *testing.T) {
-        // Create user tests
-    })
-
-    t.Run("GetUser", func(t *testing.T) {
-        // Get user tests
-    })
-
-    t.Run("UpdateUser", func(t *testing.T) {
-        // Update user tests
-    })
-
-    t.Run("DeleteUser", func(t *testing.T) {
-        // Delete user tests
-    })
-}
-```
-
-### Test Naming
-
-```go
-// Good: Descriptive test names
-func TestUserRepository_CreateUser_WithValidData_ReturnsUser(t *testing.T) {}
-func TestUserRepository_CreateUser_WithDuplicateEmail_ReturnsError(t *testing.T) {}
-func TestUserRepository_GetUser_WithNonExistentID_ReturnsNotFound(t *testing.T) {}
-
-// Bad: Vague test names
-func TestCreateUser(t *testing.T) {}
-func TestGetUser(t *testing.T) {}
-```
-
-### Assertion Strategy
-
-```go
-func TestUserCreation(t *testing.T) {
-    // Use require for critical assertions that should stop the test
-    user, err := service.CreateUser(ctx, req)
-    require.NoError(t, err)
-    require.NotNil(t, user)
-
-    // Use assert for additional checks
-    assert.NotZero(t, user.ID)
-    assert.Equal(t, req.Name, user.Name)
-    assert.Equal(t, req.Email, user.Email)
-    assert.NotZero(t, user.CreatedAt)
-}
-```
-
-### Test Data Isolation
-
-```go
-// Good: Each test creates its own data
-func TestUserService_GetActiveUsers(t *testing.T) {
-    suite := NewTestSuite(t)
-
-    // Create specific test data
-    activeUser := createTestUser(suite, "active@example.com", true)
-    inactiveUser := createTestUser(suite, "inactive@example.com", false)
-
-    users, err := service.GetActiveUsers(suite.ctx)
-    require.NoError(t, err)
-
-    // Should only contain active user
-    assert.Len(t, users, 1)
-    assert.Equal(t, activeUser.ID, users[0].ID)
-}
-
-// Bad: Relying on shared test data
-func TestUserService_GetActiveUsers_Bad(t *testing.T) {
-    // Assumes specific data exists from fixtures
-    users, err := service.GetActiveUsers(ctx)
-    require.NoError(t, err)
-    assert.Len(t, users, 2) // Fragile - depends on fixture data
-}
-```
-
-### Testing Checklist
-
-- [ ] Test database setup and teardown
-- [ ] Unit tests for business logic
-- [ ] Integration tests for database operations
-- [ ] Plan-regression tests for query plan shape
-- [ ] Golden transcript tests for behavioral stability
-- [ ] Error condition testing
-- [ ] Concurrent operation testing
-- [ ] Benchmark tests for critical paths
-- [ ] Test data isolation
-- [ ] Proper assertion strategy
-- [ ] Meaningful test names
-
-## See Also
-
-- **[Getting Started](Getting-Started)** - Basic setup and configuration
-- **[Examples](Examples)** - Practical code examples
-- **[Performance Guide](Performance-Guide)** - Performance optimization
-- **[Production Guide](Production-Guide)** - Deployment best practices
-- **[API Reference](API-Reference)** - Complete API documentation
 
 ---
 
 **[← Back to Home](Home)**
-
-*Following these testing practices will help you build reliable, maintainable applications with confidence in your database operations.*


### PR DESCRIPTION
## Summary

The docs accumulated a lot of generic infrastructure content (Redis caching, circuit breakers, factory patterns, k8s deployment patterns) and FAQ entries that missed obvious opportunities to point users at pgxkit features. Several sections also referenced behavior removed in #83 — row capture in golden, ID-column normalization, Tx "does not fire hooks".

This is a **cut pass**, not a write pass. Stacked on top of #83.

**Net diff:** 5351 deletions, 1146 insertions = **−4205 lines** across 9 files. Total docs drop from ~6800 → ~2600 lines.

## What changed per file

### `docs/Home.md`
Fixed "Zero dependencies beyond pgx" (false — uuid, difflib are direct deps), the "Type-safe operations with Go generics" overclaim (only `Retry[T]` uses generics), the "different rows" mention in the golden bullet (capture changed in #81). Trimmed the Recent Updates boilerplate.

### `docs/Getting-Started.md` (233 → 88)
Stripped the lengthy step-by-step that duplicated Examples.md. Quick install → connect → first query, plus pointers to hooks / retry / next reading.

### `docs/API-Reference.md` (961 → 925)
Updated `EnableGolden` description to reflect the new schema (no "materialized result rows", no ID-column normalization). Tightened the `TxCommit`/`TxRollback` section. Trimmed the "Best Practices" prose at the end.

### `docs/FAQ.md` (768 → 174) — **biggest cleanup target**
Every Q rewritten to point at pgxkit features:
- "My queries are slow" → **`AssertPlan`** as the regression-detection answer; `EXPLAIN ANALYZE` for ad-hoc.
- "How do I monitor performance?" → `db.Stats()` + `AfterOperation` hook in 3 lines.
- "Connection pool exhausted" → `db.Stats()` for diagnosis, `pool_max_conns` for the fix, "always defer rows.Close()" reminder.
- "Health checks" → 5 lines with `db.HealthCheck`.
- "Migrations" → one paragraph, no golang-migrate code block.

Deleted: "Can I use pgxkit with ORMs?" (non-answer), "Background job processing" (generic ticker), the giant `processLargeDataset` example, the SSL `pg_stat_ssl` snippet, the database/sql migration deep-dive.

### `docs/Examples.md` (868 → 214)
Consolidated three near-duplicate hook sections (Logging / Metrics / Transaction Outcome) into one example showing all three patterns. Collapsed four retry sub-sections into two. Deleted "Test Database Helper" (RequireDB does it), "Connection Pool Monitoring" (generic ticker), "With Other Code Generation Tools" (a non-answer), Service Layer Pattern, Advanced Health Check (a 30-line http server).

### `docs/Performance-Guide.md` (833 → 143)
Deleted entirely:
- **Caching Strategies** (~100 lines of Redis/sync.Map content with phantom `isUserModification`).
- **Smart Query Routing** (already covered).
- **Dynamic Pool Sizing** (with a literal "Note: actual implementation would require reconnecting" admission).
- **Connection Reuse** (the pool does this).
- Triplicate "Common Performance Problems / Debug Checklist / Tuning Tips".

Kept and tightened: pool sizing, monitoring with `db.Stats()`, plan-regression testing, bulk operations, streaming.

### `docs/Production-Guide.md` (843 → 125)
Deleted:
- **Circuit Breaker** (70 lines, zero pgxkit content).
- **Blue-Green Deployment / Rolling Updates** (k8s patterns, not pgxkit).
- **Dynamic Pool Scaling** (teaches a wrong mental model — pgxpool is fixed-size at connect).
- **Production Logging** wrapper struct (replaced by 15-line hook example).

Kept and tightened: configuration, RW split, health/readiness, graceful shutdown, hooks-based logging/metrics, retry policy, security checklist.

### `docs/Testing-Guide.md` (1198 → 152) — **largest single-file reduction**
Deleted:
- The custom `TestSuite` struct (RequireDB does this).
- Repository / Service Layer testing (generic Go).
- API Endpoint Testing (generic httptest).
- Table-Driven Tests / Parallel Testing (general Go).
- Fixture Files / Factory Pattern (pure SQL/Go pattern).
- Performance Testing / Benchmark Tests / Load Testing (not pgxkit).
- Connection / Query Error Testing (generic).

Kept and tightened: `RequireDB`, plan-regression testing, golden transcript testing, plan vs golden, transactions in tests, error checking with `pgx.ErrNoRows` and `pgconn.PgError`. Updated "What the Transcript Captures" to match the post-#81 schema.

### `README.md` (490 → 185)
Cut deep examples that duplicated Examples.md. Kept a "two-minute orientation" feel: install, quick start, configuration, hooks, retry, testing, type helpers, shutdown, code-gen integration, links to wiki.

## Verification

- [x] `find docs -name '*.md' -exec wc -l {} +` — 6803 → 2599 (−4204).
- [x] `grep -rn '"github.com/nhalm/pgxkit"' docs README.md` (without `/v2`) — empty.
- [x] `grep -rn 'getDuration\|isUserModification\|recordSuccess\|recordFailure\|extractOperation'` — empty.
- [x] `grep -rn 'materialized result rows\|integer columns named\|does not fire'` — empty.

## Branch base

Stacked on `issue-81-golden-hooks` (#83). Once #83 merges to main, this PR will rebase cleanly onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)