### PR TITLE
feat: add WithPoolConstructor seam for pool creation

### DIFF
--- a/db.go
+++ b/db.go
@@ -196,11 +196,13 @@ type connectConfig struct {
 	writeMaxConns   int32
 	writeMinConns   int32
 	hooks           *hooks
+	poolConstructor PoolConstructor
 }
 
 func newConnectConfig() *connectConfig {
 	return &connectConfig{
-		hooks: newHooks(),
+		hooks:           newHooks(),
+		poolConstructor: pgxpool.NewWithConfig,
 	}
 }
 
@@ -322,6 +324,37 @@ func WithOnRelease(fn func(*pgx.Conn)) ConnectOption {
 	}
 }
 
+// PoolConstructor builds a *pgxpool.Pool from a fully-prepared *pgxpool.Config.
+// It matches the signature of pgxpool.NewWithConfig, which is the default.
+type PoolConstructor func(ctx context.Context, config *pgxpool.Config) (*pgxpool.Pool, error)
+
+// WithPoolConstructor overrides how the underlying pgxpool.Pool is created.
+//
+// pgxkit prepares the *pgxpool.Config (DSN, pool sizing, and hooks) and then
+// hands it to fn instead of calling pgxpool.NewWithConfig directly. This is the
+// seam for wrapping pool creation — most usefully to attach a pgx QueryTracer
+// such as dd-trace-go's pgx integration, which has no standalone tracer
+// constructor and can only instrument a pool at construction time:
+//
+//	import ddpgx "github.com/DataDog/dd-trace-go/contrib/jackc/pgx.v5/v2"
+//
+//	db.Connect(ctx, dsn, pgxkit.WithPoolConstructor(
+//	    func(ctx context.Context, cfg *pgxpool.Config) (*pgxpool.Pool, error) {
+//	        return ddpgx.NewPoolWithConfig(ctx, cfg)
+//	    },
+//	))
+//
+// fn must build the pool from the supplied config so pgxkit's settings and
+// hooks are preserved. A nil fn is ignored (the default is kept). In
+// ConnectReadWrite, fn is invoked once per pool (read and write).
+func WithPoolConstructor(fn PoolConstructor) ConnectOption {
+	return func(c *connectConfig) {
+		if fn != nil {
+			c.poolConstructor = fn
+		}
+	}
+}
+
 // NewDB creates a new unconnected DB instance.
 // Call Connect() with options to establish the database connection.
 //
@@ -395,7 +428,7 @@ func (db *DB) Connect(ctx context.Context, dsn string, opts ...ConnectOption) er
 	db.hooks = cfg.hooks
 	db.hooks.configurePool(config)
 
-	pool, err := pgxpool.NewWithConfig(ctx, config)
+	pool, err := cfg.poolConstructor(ctx, config)
 	if err != nil {
 		return fmt.Errorf("failed to create pool: %w", err)
 	}
@@ -495,12 +528,12 @@ func (db *DB) ConnectReadWrite(ctx context.Context, readDSN, writeDSN string, op
 	db.hooks.configurePool(readConfig)
 	db.hooks.configurePool(writeConfig)
 
-	readPool, err := pgxpool.NewWithConfig(ctx, readConfig)
+	readPool, err := cfg.poolConstructor(ctx, readConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create read pool: %w", err)
 	}
 
-	writePool, err := pgxpool.NewWithConfig(ctx, writeConfig)
+	writePool, err := cfg.poolConstructor(ctx, writeConfig)
 	if err != nil {
 		readPool.Close()
 		return fmt.Errorf("failed to create write pool: %w", err)

--- a/db_test.go
+++ b/db_test.go
@@ -2,6 +2,8 @@ package pgxkit
 
 import (
 	"context"
+	"errors"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -54,6 +56,68 @@ func TestConnectOptions(t *testing.T) {
 	if cfg.maxConnIdleTime != 10*time.Minute {
 		t.Errorf("WithMaxConnIdleTime: expected %v, got %v", 10*time.Minute, cfg.maxConnIdleTime)
 	}
+}
+
+func TestPoolConstructorDefault(t *testing.T) {
+	cfg := newConnectConfig()
+	if cfg.poolConstructor == nil {
+		t.Fatal("newConnectConfig should default poolConstructor to a non-nil constructor")
+	}
+}
+
+func TestWithPoolConstructor(t *testing.T) {
+	cfg := newConnectConfig()
+
+	called := false
+	custom := func(ctx context.Context, config *pgxpool.Config) (*pgxpool.Pool, error) {
+		called = true
+		return nil, nil
+	}
+	WithPoolConstructor(custom)(cfg)
+	if _, err := cfg.poolConstructor(context.Background(), nil); err != nil {
+		t.Fatalf("custom constructor returned unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("WithPoolConstructor: custom constructor was not stored")
+	}
+
+	// A nil constructor must be ignored so the default is preserved.
+	before := cfg.poolConstructor
+	WithPoolConstructor(nil)(cfg)
+	if reflectFuncPtr(cfg.poolConstructor) != reflectFuncPtr(before) {
+		t.Error("WithPoolConstructor(nil): expected the existing constructor to be preserved")
+	}
+}
+
+// TestConnectUsesPoolConstructor proves Connect routes pool creation through the
+// injected constructor and hands it the prepared config (MaxConns applied),
+// without needing a live database: the constructor returns a sentinel error.
+func TestConnectUsesPoolConstructor(t *testing.T) {
+	var gotMaxConns int32
+	sentinel := errors.New("sentinel from custom constructor")
+
+	db := NewDB()
+	err := db.Connect(
+		context.Background(),
+		"postgres://user:pass@localhost:5432/db",
+		WithMaxConns(7),
+		WithPoolConstructor(func(_ context.Context, config *pgxpool.Config) (*pgxpool.Pool, error) {
+			gotMaxConns = config.MaxConns
+			return nil, sentinel
+		}),
+	)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Connect should surface the constructor error, got: %v", err)
+	}
+	if gotMaxConns != 7 {
+		t.Errorf("custom constructor should receive the prepared config (MaxConns=7), got %d", gotMaxConns)
+	}
+}
+
+// reflectFuncPtr returns a comparable identity for a PoolConstructor so tests can
+// assert two values point at the same function (funcs are not == comparable).
+func reflectFuncPtr(fn PoolConstructor) uintptr {
+	return reflect.ValueOf(fn).Pointer()
 }
 
 func TestConnectOptionsValidation(t *testing.T) {


### PR DESCRIPTION
## Problem

`pgxkit` builds its `*pgxpool.Pool` internally via `pgxpool.NewWithConfig`, and there's no way for callers to wrap that construction step. That makes it impossible to attach a pgx `QueryTracer` to the pool — which is exactly what APM/tracing integrations need.

Concretely: **dd-trace-go's pgx v5 integration exposes no standalone tracer constructor.** Its only injection point is `NewPoolWithConfig`, which wraps `config.ConnConfig.Tracer` and then calls `pgxpool.NewWithConfig` itself. With pgxkit owning pool construction and offering no seam, the only fallback is Orchestrion compile-time instrumentation — which doesn't reliably rewrite the call site *inside* the pgxkit dependency, so DB query spans silently never appear.

## Change

Add `WithPoolConstructor(fn)` — an injectable pool factory whose signature matches `pgxpool.NewWithConfig` (the default).

- pgxkit still prepares the full `*pgxpool.Config` (DSN, pool sizing, hooks) and then hands it to `fn` instead of calling `pgxpool.NewWithConfig` directly, so **all existing settings and hooks are preserved**.
- Defaults to `pgxpool.NewWithConfig`; a `nil` fn is ignored (default kept).
- Applied in both `Connect` and `ConnectReadWrite` (invoked once per pool).

Usage — attaching dd-trace-go's pgx tracer:

```go
import ddpgx "github.com/DataDog/dd-trace-go/contrib/jackc/pgx.v5/v2"

db.Connect(ctx, dsn, pgxkit.WithPoolConstructor(
    func(ctx context.Context, cfg *pgxpool.Config) (*pgxpool.Pool, error) {
        return ddpgx.NewPoolWithConfig(ctx, cfg)
    },
))
```

## Tests

Added `TestPoolConstructorDefault`, `TestWithPoolConstructor` (incl. nil-is-ignored), and `TestConnectUsesPoolConstructor` — the last proves `Connect` routes construction through the injected factory and hands it the prepared config (asserts `MaxConns` applied), using a sentinel-error constructor so no live database is required. `go build`, `go vet`, and the new tests all pass.

## Compatibility

Purely additive — new option, default behavior unchanged. No change to any existing signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)